### PR TITLE
Feature/merge tours activities

### DIFF
--- a/.ai/scripts/add-filter-booleans.ps1
+++ b/.ai/scripts/add-filter-booleans.ps1
@@ -1,0 +1,41 @@
+$ErrorActionPreference = "Stop"
+$token = "F_Wy4mJ-iBRJP9gstTqaMFRg8v_1MniD"
+$base = "https://cm-marketing.directus.app"
+$headers = @{
+	Authorization = "Bearer $token"
+	"Content-Type" = "application/json"
+}
+
+$booleans = @(
+	@{ field = "filter_language_enabled"; note = "Show language filter control in UI" },
+	@{ field = "filter_category_enabled"; note = "Show experience_category filter control in UI" },
+	@{ field = "filter_discount_enabled"; note = "Show promo_discount_percent filter control in UI" },
+	@{ field = "filter_duration_enabled"; note = "Show duration filter control in UI" },
+	@{ field = "filter_distance_enabled"; note = "Show distance-from-reference-point filter control in UI" }
+)
+
+foreach ($b in $booleans) {
+	$body = @{
+		field = $b.field
+		type = "boolean"
+		schema = @{
+			default_value = $true
+			is_nullable = $false
+		}
+		meta = @{
+			interface = "boolean"
+			special = @("cast-boolean")
+			note = $b.note
+			width = "half"
+			options = @{ label = "Visible" }
+		}
+	} | ConvertTo-Json -Depth 10
+
+	Write-Host "Creating field: $($b.field)"
+	try {
+		$r = Invoke-RestMethod -Uri "$base/fields/stopover_mixed_experience_module" -Method POST -Headers $headers -Body $body -ErrorAction Stop
+		Write-Host "  OK: $($r.data.field)"
+	} catch {
+		Write-Host "  ERROR: $($_.ErrorDetails.Message)"
+	}
+}

--- a/.ai/scripts/add-translation-fields.ps1
+++ b/.ai/scripts/add-translation-fields.ps1
@@ -1,0 +1,43 @@
+$ErrorActionPreference = "Stop"
+$token = "F_Wy4mJ-iBRJP9gstTqaMFRg8v_1MniD"
+$base = "https://cm-marketing.directus.app"
+$headers = @{
+	Authorization = "Bearer $token"
+	"Content-Type" = "application/json"
+}
+
+$fields = @(
+	@{ field = "reference_point_label"; max = 80; note = "Text shown next to the distance filter (e.g. 'Measured from Iglesia del Carmen, Via Espana')" },
+	@{ field = "filter_language_label"; max = 40; note = "UI label for the language filter control" },
+	@{ field = "filter_category_label"; max = 40; note = "UI label for the experience_category filter control" },
+	@{ field = "filter_discount_label"; max = 40; note = "UI label for the discount filter control" },
+	@{ field = "filter_duration_label"; max = 40; note = "UI label for the duration filter control" },
+	@{ field = "filter_distance_label"; max = 40; note = "UI label for the distance filter control" },
+	@{ field = "filter_apply_label"; max = 30; note = "Text for the 'Apply filters' button" }
+)
+
+foreach ($f in $fields) {
+	$body = @{
+		field = $f.field
+		type = "string"
+		schema = @{
+			max_length = $f.max
+			is_nullable = $true
+			default_value = $null
+		}
+		meta = @{
+			interface = "input"
+			note = $f.note
+			width = "half"
+			required = $false
+		}
+	} | ConvertTo-Json -Depth 10
+
+	Write-Host "Creating field: $($f.field) (max $($f.max))"
+	try {
+		$r = Invoke-RestMethod -Uri "$base/fields/stopover_mixed_experience_module_translations" -Method POST -Headers $headers -Body $body -ErrorAction Stop
+		Write-Host "  OK: $($r.data.field)"
+	} catch {
+		Write-Host "  ERROR: $($_.ErrorDetails.Message)"
+	}
+}

--- a/.ai/scripts/create-sources-translations.ps1
+++ b/.ai/scripts/create-sources-translations.ps1
@@ -1,0 +1,168 @@
+$ErrorActionPreference = "Stop"
+$token = "F_Wy4mJ-iBRJP9gstTqaMFRg8v_1MniD"
+$base = "https://cm-marketing.directus.app"
+$headers = @{
+	Authorization = "Bearer $token"
+	"Content-Type" = "application/json"
+}
+
+function Invoke-Step {
+	param($label, $url, $method = "POST", $body)
+	Write-Host ""
+	Write-Host "=== $label ==="
+	try {
+		$r = Invoke-RestMethod -Uri $url -Method $method -Headers $headers -Body $body -ErrorAction Stop
+		Write-Host "  OK"
+		return $r
+	} catch {
+		Write-Host "  ERROR: $($_.ErrorDetails.Message)"
+		return $null
+	}
+}
+
+# Step 1: Create the collection with a primary id field
+$step1 = @{
+	collection = "stopover_mixed_experience_module_sources_translations"
+	meta = @{
+		hidden = $true
+		group = "stopover_mixed_experience_module"
+		icon = "import_export"
+		accountability = "all"
+		versioning = $false
+		collapse = "open"
+		singleton = $false
+	}
+	schema = @{
+		name = "stopover_mixed_experience_module_sources_translations"
+	}
+	fields = @(
+		@{
+			field = "id"
+			type = "integer"
+			meta = @{
+				hidden = $true
+				interface = "numeric"
+				readonly = $true
+			}
+			schema = @{
+				is_primary_key = $true
+				has_auto_increment = $true
+				is_nullable = $false
+			}
+		}
+	)
+} | ConvertTo-Json -Depth 10
+
+Invoke-Step -label "Create collection" -url "$base/collections" -body $step1 | Out-Null
+
+# Step 2: Create the 'translations' alias field on the parent sources collection
+$step2 = @{
+	field = "translations"
+	type = "alias"
+	meta = @{
+		special = @("translations")
+		interface = "translations"
+		options = @{
+			languageField = "name"
+			defaultOpenSplitView = $true
+		}
+		display = "translations"
+		hidden = $false
+		required = $false
+	}
+	schema = $null
+} | ConvertTo-Json -Depth 10
+
+Invoke-Step -label "Create translations alias on sources" -url "$base/fields/stopover_mixed_experience_module_sources" -body $step2 | Out-Null
+
+# Step 3: Create 'label' field
+$step3 = @{
+	field = "label"
+	type = "string"
+	meta = @{
+		interface = "input"
+		note = "Visible name of the entity type (e.g. Tour / Activity / Actividad)"
+		width = "full"
+		required = $false
+	}
+	schema = @{
+		max_length = 40
+		is_nullable = $true
+	}
+} | ConvertTo-Json -Depth 10
+
+Invoke-Step -label "Create field 'label'" -url "$base/fields/stopover_mixed_experience_module_sources_translations" -body $step3 | Out-Null
+
+# Step 4: Create FK field stopover_mixed_experience_module_sources_id
+$step4 = @{
+	field = "stopover_mixed_experience_module_sources_id"
+	type = "integer"
+	meta = @{
+		hidden = $true
+		interface = "select-dropdown-m2o"
+		required = $false
+	}
+	schema = @{
+		is_nullable = $true
+	}
+} | ConvertTo-Json -Depth 10
+
+Invoke-Step -label "Create FK field 'stopover_mixed_experience_module_sources_id'" -url "$base/fields/stopover_mixed_experience_module_sources_translations" -body $step4 | Out-Null
+
+# Step 5: Create FK field languages_code
+$step5 = @{
+	field = "languages_code"
+	type = "string"
+	meta = @{
+		hidden = $true
+		interface = "select-dropdown-m2o"
+		required = $false
+	}
+	schema = @{
+		max_length = 255
+		is_nullable = $true
+	}
+} | ConvertTo-Json -Depth 10
+
+Invoke-Step -label "Create FK field 'languages_code'" -url "$base/fields/stopover_mixed_experience_module_sources_translations" -body $step5 | Out-Null
+
+# Step 6: Create relation for languages_code -> languages.code
+$step6 = @{
+	collection = "stopover_mixed_experience_module_sources_translations"
+	field = "languages_code"
+	related_collection = "languages"
+	meta = @{
+		junction_field = "stopover_mixed_experience_module_sources_id"
+		one_field = $null
+		one_deselect_action = "nullify"
+		sort_field = $null
+	}
+	schema = @{
+		on_update = "NO ACTION"
+		on_delete = "NO ACTION"
+	}
+} | ConvertTo-Json -Depth 10
+
+Invoke-Step -label "Create relation languages_code -> languages" -url "$base/relations" -body $step6 | Out-Null
+
+# Step 7: Create relation for stopover_mixed_experience_module_sources_id -> sources.id
+$step7 = @{
+	collection = "stopover_mixed_experience_module_sources_translations"
+	field = "stopover_mixed_experience_module_sources_id"
+	related_collection = "stopover_mixed_experience_module_sources"
+	meta = @{
+		junction_field = "languages_code"
+		one_field = "translations"
+		one_deselect_action = "delete"
+		sort_field = $null
+	}
+	schema = @{
+		on_update = "NO ACTION"
+		on_delete = "CASCADE"
+	}
+} | ConvertTo-Json -Depth 10
+
+Invoke-Step -label "Create relation sources_id -> sources" -url "$base/relations" -body $step7 | Out-Null
+
+Write-Host ""
+Write-Host "=== DONE ==="

--- a/.ai/scripts/fix-sources-translations-config.ps1
+++ b/.ai/scripts/fix-sources-translations-config.ps1
@@ -1,0 +1,90 @@
+$ErrorActionPreference = "Stop"
+$token = "F_Wy4mJ-iBRJP9gstTqaMFRg8v_1MniD"
+$base = "https://cm-marketing.directus.app"
+$headers = @{
+	Authorization = "Bearer $token"
+	"Content-Type" = "application/json"
+}
+
+function Patch-Field {
+	param($collection, $field, $body)
+	Write-Host "PATCH $collection/$field"
+	try {
+		Invoke-RestMethod -Uri "$base/fields/$collection/$field" -Method PATCH -Headers $headers -Body $body -ErrorAction Stop | Out-Null
+		Write-Host "  OK"
+	} catch {
+		Write-Host "  ERROR: $($_.ErrorDetails.Message)"
+	}
+}
+
+# 1) Fix FK fields: remove explicit interface (null), keep them hidden, fix sort order
+#    Pattern from working module_translations: FKs sort=2 and 3, content sort=4+
+
+$fixFkSources = @{
+	meta = @{
+		interface = $null
+		hidden = $true
+		sort = 2
+		width = "full"
+		readonly = $false
+		required = $false
+	}
+} | ConvertTo-Json -Depth 10
+Patch-Field "stopover_mixed_experience_module_sources_translations" "stopover_mixed_experience_module_sources_id" $fixFkSources
+
+$fixFkLang = @{
+	meta = @{
+		interface = $null
+		hidden = $true
+		sort = 3
+		width = "full"
+		readonly = $false
+		required = $false
+	}
+} | ConvertTo-Json -Depth 10
+Patch-Field "stopover_mixed_experience_module_sources_translations" "languages_code" $fixFkLang
+
+# 2) Fix id field: remove explicit interface, restore defaults
+$fixId = @{
+	meta = @{
+		interface = $null
+		hidden = $true
+		sort = 1
+		width = "full"
+		readonly = $true
+	}
+} | ConvertTo-Json -Depth 10
+Patch-Field "stopover_mixed_experience_module_sources_translations" "id" $fixId
+
+# 3) Move label to sort=4 and make it required
+$fixLabel = @{
+	meta = @{
+		interface = "input"
+		hidden = $false
+		sort = 4
+		width = "full"
+		required = $true
+		note = "Visible name of the entity type (e.g. Tour / Activity / Actividad)"
+	}
+} | ConvertTo-Json -Depth 10
+Patch-Field "stopover_mixed_experience_module_sources_translations" "label" $fixLabel
+
+# 4) Make the 'translations' alias on parent required (same as working pattern)
+$fixAlias = @{
+	meta = @{
+		special = @("translations")
+		interface = "translations"
+		options = @{
+			languageField = "name"
+			defaultOpenSplitView = $true
+		}
+		display = "translations"
+		hidden = $false
+		required = $true
+		width = "full"
+	}
+} | ConvertTo-Json -Depth 10
+Patch-Field "stopover_mixed_experience_module_sources" "translations" $fixAlias
+
+Write-Host ""
+Write-Host "=== DONE ==="

--- a/.ai/scripts/seed-sources-translations.ps1
+++ b/.ai/scripts/seed-sources-translations.ps1
@@ -1,0 +1,35 @@
+$ErrorActionPreference = "Stop"
+$token = "F_Wy4mJ-iBRJP9gstTqaMFRg8v_1MniD"
+$base = "https://cm-marketing.directus.app"
+$headers = @{
+	Authorization = "Bearer $token"
+	"Content-Type" = "application/json"
+}
+
+# Labels taken from the hardcoded strings in mixed-experience-module.svelte (lines 85-105)
+# source id 1 = stopover_place_to_visit (Activity)
+# source id 2 = stopover_tours (Tour)
+$seeds = @(
+	@{ source = 1; lang = "en"; label = "Activity" },
+	@{ source = 1; lang = "es"; label = "Actividad" },
+	@{ source = 1; lang = "pt"; label = "Atividade" },
+	@{ source = 2; lang = "en"; label = "Tour" },
+	@{ source = 2; lang = "es"; label = "Tour" },
+	@{ source = 2; lang = "pt"; label = "Tour" }
+)
+
+foreach ($s in $seeds) {
+	$body = @{
+		stopover_mixed_experience_module_sources_id = $s.source
+		languages_code = $s.lang
+		label = $s.label
+	} | ConvertTo-Json -Depth 5
+
+	Write-Host "Seeding: source=$($s.source) lang=$($s.lang) label=$($s.label)"
+	try {
+		$r = Invoke-RestMethod -Uri "$base/items/stopover_mixed_experience_module_sources_translations" -Method POST -Headers $headers -Body $body -ErrorAction Stop
+		Write-Host "  OK: id=$($r.data.id)"
+	} catch {
+		Write-Host "  ERROR: $($_.ErrorDetails.Message)"
+	}
+}

--- a/.cursor/rules/60-directus-schema-via-api.mdc
+++ b/.cursor/rules/60-directus-schema-via-api.mdc
@@ -1,0 +1,80 @@
+﻿---
+description: When modifying Directus schema via the REST API (POST /fields, /relations, /collections), follow the patterns below to avoid silent misconfigurations.
+globs: ".ai/scripts/**/*.ps1,.ai/scripts/**/*.sh,.ai/scripts/**/*.ts"
+alwaysApply: false
+---
+
+# Directus schema changes via REST API
+
+Use `DIRECTUS_TOKEN` from `.env.agent`. The user's token needs a policy with
+`admin_access: true` attached to it - CRUD access to `directus_fields` alone is
+NOT enough for `POST /fields`. Verify with `GET /schema/snapshot` first (admin-only).
+
+## Golden rule: `one_field` must be re-linked after the alias exists
+
+When creating an O2M/M2M relation via `POST /relations` with
+`meta.one_field: "<alias_name>"`, Directus silently drops `one_field` if the
+alias field on the parent collection does not already exist at that moment.
+The relation appears created, but `GET /relations/...` returns `one_field: null`.
+
+The translations interface (and other interfaces that look up
+`many_collection.field` via the parent's `one_field`) will fail with:
+
+> Interface "translations" not found.
+
+Always do this in order:
+
+1. Create the junction collection (`POST /collections`) with at least the `id` PK field.
+2. Create the alias field on the parent FIRST:
+   ```
+   POST /fields/<parent_collection>
+   { field: "translations", type: "alias",
+     meta: { special: ["translations"], interface: "translations",
+             options: { languageField: "name", defaultOpenSplitView: true },
+             display: "translations", required: true, hidden: false } }
+   ```
+3. Create the two FK fields in the junction (content fields can come after).
+4. Create the two relations - the one pointing at the parent includes
+   `meta.one_field: "translations"`.
+5. Verify: `GET /relations/<junction>` must show `one_field: "translations"` on
+   the parent relation. If empty, `PATCH` the relation:
+   ```
+   PATCH /relations/<junction>/<fk_to_parent>
+   { meta: { one_field: "translations", junction_field: "languages_code",
+             one_deselect_action: "delete" } }
+   ```
+
+## Translations junction collection - canonical shape
+
+Mirror an existing working pair (e.g. `stopover_mixed_experience_module` +
+`stopover_mixed_experience_module_translations`) when creating new ones:
+
+- Junction collection: `hidden: true`, grouped under the parent.
+- Field sort order matters: `id` (1), FK to parent (2), `languages_code` (3),
+  then content fields (4+). FK fields should be `hidden: true`, `interface: null`,
+  `special: null` - let Directus infer the M2O interface from the schema FK.
+- Content fields use `interface: "input"` and typically `required: true`.
+- Parent alias is `required: true`, `display: "translations"`, not hidden.
+
+## Language codes
+
+The CMS uses short ISO codes (`en`, `es`, `pt`) - NOT regional variants like
+`es-PA` or `en-US`. The `languages` collection has `code` (PK) and `name`
+(display). The translations interface uses `languageField: "name"`.
+
+## Verification checklist after any schema change
+
+- `GET /fields/<collection>` - new fields present with expected `sort`, `hidden`, `required`.
+- `GET /relations/<junction>` - both sides present, `junction_field` cross-references
+  correct, `one_field` populated only on the parent side.
+- `GET /items/<parent>?fields=translations.languages_code,translations.<content_field>`
+  returns the expected tree.
+- Hard-refresh the Directus Studio (Ctrl+Shift+R) to flush the interface registry
+  cache before concluding a config is broken.
+
+## Scripts live in `.ai/scripts/`
+
+Idempotent PowerShell scripts that hit the Directus REST API. Naming convention:
+`add-*.ps1` (create fields), `create-*.ps1` (create collections), `seed-*.ps1`
+(insert data), `fix-*.ps1` (patch existing config). Keep the token at the top
+of the script as a local variable, reading from `.env.agent` which is gitignored.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,39 @@
+# Documentation Index
+
+Central index for all documentation in the Panama Stopover SvelteKit site.
+
+---
+
+## Project docs (`/docs`)
+
+| File | Description |
+|------|-------------|
+| [cms.md](./cms.md) | CMS (Directus) entities, flows, approval process and permissions |
+| [server.md](./server.md) | Server and infrastructure notes |
+| [REPOSITORY_STRUCTURE.md](./REPOSITORY_STRUCTURE.md) | Full directory structure and architecture overview |
+| [mixed-experience-module.md](./mixed-experience-module.md) | Mixed Experience Module — activities & tours merge feature |
+
+---
+
+## Other READMEs in the repo
+
+| Location | Description |
+|----------|-------------|
+| [`/README.md`](../README.md) | Project root — setup, environment variables, running locally |
+| [`/src/lib/domain/README.md`](../src/lib/domain/README.md) | Domain layer: pages, schemas and DDD conventions |
+| [`/src/lib/components/COMPONENT_TYPING_GUIDE.md`](../src/lib/components/COMPONENT_TYPING_GUIDE.md) | Component typing patterns with Directus schemas |
+| [`/.github/workflows/README.md`](../.github/workflows/README.md) | CI/CD pipeline and GitHub Actions workflows |
+
+---
+
+## Internal / refactor notes (`.ai/`)
+
+These are working notes generated during refactors and migrations. Kept for reference, not maintained.
+
+| File | Description |
+|------|-------------|
+| `.ai/refactor/MIGRATION_PROGRESS.md` | SSG + Svelte 5 migration progress log |
+| `.ai/refactor/COMPONENT_MIGRATION_COMPLETE.md` | Component migration completion summary |
+| `.ai/refactor/REFACTOR_FINAL_STATUS.md` | Final status of the SSG refactorization |
+| `.ai/guides/DOPPLER_SETUP.md` | Doppler secrets manager setup guide |
+| `.ai/guides/ENV_SETUP_GUIDE.md` | Environment variables setup guide |

--- a/docs/implementation-spec-v2.md
+++ b/docs/implementation-spec-v2.md
@@ -1,0 +1,602 @@
+---
+title: "Implementation Spec v2 — Join: Filters, Sorting & Translations"
+type: synthesis
+tags: [spec, directus, svelte, filters, sorting, translations, implementation]
+created: 2026-04-17
+updated: 2026-04-17
+sources: [chatgpt-modeling, filters-and-sorting-spec]
+confidence: high
+---
+
+# Implementation Spec v2 — Join: Filters, Sorting & Translations
+
+> **Para Cursor:** Este documento especifica todos los cambios de Directus y frontend necesarios.
+> El Join ya está publicado en panama-stopover.com. Esta es la segunda iteración.
+> Implementa en el orden indicado; cada sección es independiente salvo que se indique lo contrario.
+
+---
+
+## Estado actual
+
+### Directus — completado (2026-04-17)
+
+**Colecciones**
+- ✅ `stopover_mixed_experience_module` con: `key`, `max_items`, `prefilter`, `sort`, `sources` (O2M), `translations` (O2M), y los 5 booleans `filter_*_enabled` (default true, not null)
+- ✅ `stopover_mixed_experience_module_translations` con los 10 campos originales + los 7 nuevos (`reference_point_label`, `filter_language_label`, `filter_category_label`, `filter_discount_label`, `filter_duration_label`, `filter_distance_label`, `filter_apply_label`) — todos nullable, interface `input`
+- ✅ `stopover_mixed_experience_module_sources` con: `id`, `entity_type`, `max_items`, `module_id`, `status`, `translations` (O2M, nueva)
+- ✅ `stopover_mixed_experience_module_sources_translations` creada con: `id` (PK), `stopover_mixed_experience_module_sources_id` (FK → sources.id CASCADE), `languages_code` (FK → languages.code), `label` (string 40, nullable)
+
+**Seed data**
+- ✅ 6 rows en `sources_translations`: 2 sources × 3 idiomas (`en`/`es`/`pt`)
+  - source 1 (`stopover_place_to_visit`): Activity / Actividad / Atividade
+  - source 2 (`stopover_tours`): Tour / Tour / Tour
+
+**Campos ya existentes en tours / places (validados)**
+- `meeting_point: GeoJSON` en `stopover_tour`
+- `location: GeoJSON` en `stopover_place_to_visit`
+- `experience_category: number` (M2O) en ambos
+- `duration` — ⚠️ `number` en tours, `string` en places → normalizar a `number`
+- `supported_languages: Record<string, unknown>` (jsonb) en ambos
+- `priority`, `promo_discount_percent`, `promo_discount_amount`, `date_created` en ambos
+
+### Contenido existente en el CMS
+
+Único módulo publicado: `activities-and-tour-merge` (`max_items: 6`, `prefilter: promotions`).
+
+- Sources: `stopover_place_to_visit` (id=1, max_items=3) + `stopover_tours` (id=2, max_items=3)
+- Translations pobladas sólo en `title`, `primary_cta_label`, `secondary_cta_label` para `en`/`es`/`pt`
+- `description`, `disclaimer_text`, `primary_cta_url`, `secondary_cta_url` están vacíos
+- Nuevos `reference_point_label`, `filter_*_label`, `filter_apply_label` están vacíos → cargar desde CMS
+
+### Pendiente en Directus (contenido editorial)
+- [ ] Cargar valores para `reference_point_label`, `filter_language_label`, `filter_category_label`, `filter_discount_label`, `filter_duration_label`, `filter_distance_label`, `filter_apply_label` en los 3 idiomas desde el Directus Studio
+
+### Pendiente en Frontend
+- [ ] Actualizar Zod schema local `src/lib/directus/stopover_mixed_experience_module.ts`
+- [ ] Registrar `stopover_mixed_experience_module_sources_translations` en `src/lib/infrastructure/directus/schema.d.ts`
+- [ ] PARTES 4 a 8 del spec (query, helpers, normalización, filtros, sort)
+
+---
+
+## Contexto
+
+El módulo `stopover_mixed_experience_module` renderiza una lista unificada de items de
+`stopover_tours` y `stopover_place_to_visit`. La unificación es UX-only: las colecciones
+permanecen separadas en Directus; el merge ocurre en el frontend Svelte.
+
+Campos comunes entre ambas colecciones (confirmados en generated types del submodule):
+- `supported_languages` (jsonb / `Record<string, unknown>`) — multi-select serializado
+- `promo_discount_percent` (number)
+- `experience_category` (`number` / M2O — single select, NO multi como asumía el spec original)
+- `duration` — **⚠️ `number` en tours, `string` en places** → requiere normalización a `number`
+- `meeting_point` en tours / `location` en places (ambos `GeoJSON`)
+
+---
+
+## Permisos necesarios para implementar
+
+Siguiendo la convención documentada en `docs/cms.md` §5 (dev / preview / prod).
+
+### En Directus (rol admin o equivalente con schema edit)
+
+Necesarios **antes** de empezar con el frontend:
+
+- [ ] **Schema edit** en el proyecto Directus de dev para:
+  - Agregar 5 campos `boolean` a `stopover_mixed_experience_module` (PARTE 2)
+  - Agregar 7 campos `string` a `stopover_mixed_experience_module_translations` (PARTE 1.1)
+  - Crear la colección `stopover_mixed_experience_module_sources_translations` con sus relaciones (PARTE 1.2)
+- [ ] **Permisos de lectura (`read`)** para el rol **API público / anónimo** usado por el build:
+  - `stopover_mixed_experience_module_sources_translations.*` (colección nueva)
+  - Nuevos campos en `stopover_mixed_experience_module` y `_translations` (Directus requiere habilitar cada campo explícitamente cuando se usa field-level permissions)
+- [ ] **Permisos de escritura (`create` / `update`)** para el rol de editores de CMS en las tres colecciones, replicando el patrón existente del módulo
+- [ ] Aplicar la misma configuración de permisos en **dev, preview y prod** (ver `docs/cms.md` §5):
+  - dev: lectura de todo el contenido, incluye drafts
+  - preview: idéntico a dev pero emulando el comportamiento de preview-mode
+  - prod: sólo contenido con `status = published`
+
+### Sobre el token de API
+
+El Static Token que usa el cliente de Directus (`DIRECTUS_TOKEN` vía Doppler) debe tener acceso a:
+
+- La colección nueva `stopover_mixed_experience_module_sources_translations`
+- Los campos nuevos en las dos colecciones existentes
+
+Si el token hereda permisos del rol público, basta con cumplir el checklist anterior. Si usa un rol dedicado, agregar los mismos permisos ahí.
+
+### En el repo `directus-cms-collections`
+
+Después de aplicar los cambios de schema en Directus (dev):
+
+- [ ] Acceso de escritura al repo del submodule para **regenerar tipos** con el generador (`pnpm generate` o equivalente dentro del submodule)
+- [ ] Acceso de commit/push en la rama `main` del submodule
+- [ ] Una vez mergeado, actualizar la referencia del submodule en este repo con `git submodule update --remote`
+
+### En el repo principal (sveltekit-site)
+
+- [ ] Acceso de escritura para modificar los siguientes archivos:
+  - `src/lib/directus/stopover_mixed_experience_module.ts` (Zod schema)
+  - `src/lib/directus/section.ts` y `src/lib/directus/content-group.ts` (si cambia la forma del item)
+  - `src/lib/infrastructure/directus/schema.d.ts` (agregar la nueva colección al `Schema`)
+  - `src/routes/[...path]/+page.server.ts`
+  - `src/routes/utils.ts`
+  - `src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte`
+- [ ] Permiso de PR en `dev` del repo principal
+
+### Flujo ordenado (dependencias entre permisos)
+
+1. Admin Directus aplica schema y permisos en **dev** → regenerar tipos en submodule → PR en submodule
+2. Submodule mergeado → bump del puntero en el repo principal → PR de frontend
+3. QA en dev+preview → replicar cambios de schema/permisos en **prod**
+4. Merge a `main` y deploy
+
+### Datos / Contenido
+
+- [ ] Acceso de editor al CMS de dev para:
+  - Cargar los 4 registros iniciales de `sources_translations` (PARTE 3.1)
+  - Verificar que todos los módulos existentes queden con los 5 booleans en `true` después de la migración (PARTE 2)
+  - Añadir traducciones de filtros (`filter_*_label`, `filter_apply_label`, `reference_point_label`) al menos en `es-PA` y `en-US`
+
+---
+
+## PARTE 1 — Directus: nuevas colecciones de traducciones
+
+### 1.1 `stopover_mixed_experience_module_translations`
+
+La colección **ya existe**. Solo agregar los campos faltantes:
+
+```
+Campos YA EXISTENTES (no tocar):
+  ✅ languages_code, title, description, disclaimer_text
+  ✅ primary_cta_label, primary_cta_url, primary_cta
+  ✅ secondary_cta_label, secondary_cta_url, secondary_cta
+  ✅ stopover_mixed_experience_module_key (relación al módulo padre)
+
+Campos A AGREGAR (todos nullable):
+  reference_point_label  string   max 80   — texto del punto de referencia geográfico
+                                             ej. "Medido desde Iglesia del Carmen, Vía España"
+  filter_language_label  string   max 40   — label del filtro de idioma en UI
+  filter_category_label  string   max 40
+  filter_discount_label  string   max 40
+  filter_duration_label  string   max 40
+  filter_distance_label  string   max 40
+  filter_apply_label     string   max 30   — label del botón "Aplicar filtros"
+                                             ej. es-PA: "Aplicar" | en-US: "Apply"
+```
+
+### 1.2 `stopover_mixed_experience_module_sources_translations`
+
+❌ **No existe todavía.** Crear esta colección:
+
+```
+Relaciones:
+  source_id      M2O → stopover_mixed_experience_module_sources
+                 (field en padre: "translations", interface: translations)
+  languages_code M2O → languages
+
+Campos:
+  label   string   max 40   nullable
+          — nombre visible del tipo de entidad
+            ej. es-PA: "Tour" / "Actividad" | en-US: "Tour" / "Activity"
+```
+
+> **Nota sobre `sources`:** la colección `stopover_mixed_experience_module_sources`
+> ya existe con los campos `id`, `entity_type`, `max_items`, `module_id`, `status`.
+> `max_items` a nivel de source ya está listo para usarse como cap individual.
+
+---
+
+## PARTE 2 — Directus: nuevos campos en `stopover_mixed_experience_module`
+
+Agregar 5 campos booleanos. **Default: true** (todos los filtros activos al crear un módulo nuevo).
+
+```
+filter_language_enabled   boolean   default true
+filter_category_enabled   boolean   default true
+filter_discount_enabled   boolean   default true
+filter_duration_enabled   boolean   default true
+filter_distance_enabled   boolean   default true
+```
+
+**Importante:** No crear `category_filter_mode` — no existe y no debe crearse. Los 5 booleans son su reemplazo unificado.
+
+---
+
+## PARTE 3 — Directus: migración de datos iniciales
+
+Una vez creadas las colecciones de traducciones, cargar los valores actuales hardcodeados.
+
+### 3.1 `sources_translations` — entity type labels
+
+Los idiomas reales del CMS son códigos ISO cortos: `en`, `es`, `pt` (NO `en-US`/`es-PA`).
+El `entity_type` actual del módulo `activities-and-tour-merge` es `stopover_place_to_visit`
+y `stopover_tours` (plural). Seed ya cargado:
+
+| `source.id` | `entity_type` | `languages_code` | `label` |
+|---|---|---|---|
+| 1 | `stopover_place_to_visit` | `en` | Activity |
+| 1 | `stopover_place_to_visit` | `es` | Actividad |
+| 1 | `stopover_place_to_visit` | `pt` | Atividade |
+| 2 | `stopover_tours` | `en` | Tour |
+| 2 | `stopover_tours` | `es` | Tour |
+| 2 | `stopover_tours` | `pt` | Tour |
+
+> Nota: si se desea usar "Passeio" en portugués (congruente con el title del módulo
+> "Atividades e Passeios"), editar el valor desde Directus Studio. Los seeds iniciales
+> preservaron los strings actualmente hardcodeados en `mixed-experience-module.svelte`
+> (líneas 88–92) para minimizar cambios visuales.
+
+### 3.2 `module_translations` — contenido existente
+
+Si el módulo ya tiene contenido (title, description, CTAs) cargado directamente en campos
+de la tabla principal, migrar esos valores a la colección de traducciones con el idioma
+correspondiente antes de borrar los campos originales.
+
+---
+
+## PARTE 4 — Frontend: query de Directus
+
+Actualizar el query del módulo para incluir traducciones:
+
+```
+GET /items/stopover_mixed_experience_module/{id}
+  ?fields=
+    id,
+    max_items,
+    prefilter,
+    primary_cta_url,
+    secondary_cta_url,
+    filter_language_enabled,
+    filter_category_enabled,
+    filter_discount_enabled,
+    filter_duration_enabled,
+    filter_distance_enabled,
+    translations.languages_code,
+    translations.title,
+    translations.description,
+    translations.disclaimer_text,
+    translations.primary_cta_label,
+    translations.secondary_cta_label,
+    translations.reference_point_label,
+    translations.filter_language_label,
+    translations.filter_category_label,
+    translations.filter_discount_label,
+    translations.filter_duration_label,
+    translations.filter_distance_label,
+    sources.id,
+    sources.entity_type,
+    sources.max_items,
+    sources.status,
+    sources.translations.languages_code,
+    sources.translations.label
+```
+
+---
+
+## PARTE 5 — Frontend: helper de idioma
+
+Si no existe ya, agregar:
+
+```typescript
+function pickTranslation<T extends { languages_code: string }>(
+  translations: T[],
+  lang: string,
+  fallback = 'es-PA'
+): T | undefined {
+  return (
+    translations.find(t => t.languages_code === lang) ??
+    translations.find(t => t.languages_code === fallback) ??
+    translations[0]
+  );
+}
+```
+
+---
+
+## PARTE 6 — Frontend: normalización del card model
+
+### 6.1 Campo `geoPoint`
+
+Al normalizar cada ítem del pool unificado:
+
+```typescript
+// Tours:
+geoPoint: item.meeting_point ?? null,
+
+// Activities:
+geoPoint: item.location ?? null,
+```
+
+**Confirmado** en `directus-cms-collections`: ambos campos son de tipo `GeoJSON`
+(formato `{ type: "Point", coordinates: [lng, lat] }`). La función `haversineKm`
+debe acceder como:
+
+```typescript
+const lng = geoPoint.coordinates[0];
+const lat = geoPoint.coordinates[1];
+```
+
+### 6.2 Campo `distanceFromCenter`
+
+Calcular durante la normalización usando haversine.
+Punto de referencia fijo: **Iglesia del Carmen, Vía España** — `{ lat: 8.9936, lng: -79.5197 }`.
+
+```typescript
+const IGLESIA_DEL_CARMEN = { lat: 8.9936, lng: -79.5197 };
+
+function haversineKm(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number }
+): number {
+  const R = 6371;
+  const dLat = ((b.lat - a.lat) * Math.PI) / 180;
+  const dLng = ((b.lng - a.lng) * Math.PI) / 180;
+  const sinLat = Math.sin(dLat / 2);
+  const sinLng = Math.sin(dLng / 2);
+  const x =
+    sinLat * sinLat +
+    Math.cos((a.lat * Math.PI) / 180) *
+      Math.cos((b.lat * Math.PI) / 180) *
+      sinLng * sinLng;
+  return R * 2 * Math.atan2(Math.sqrt(x), Math.sqrt(1 - x));
+}
+
+// En la normalización de cada ítem:
+distanceFromCenter: item.geoPoint
+  ? haversineKm(IGLESIA_DEL_CARMEN, item.geoPoint)
+  : null,
+```
+
+### 6.3 Label del entity type desde translations
+
+Reemplazar cualquier string hardcodeado de tipo `"Tour"` / `"Activity"` / `"Actividad"` por:
+
+```typescript
+// source = el objeto de stopover_mixed_experience_module_sources
+const sourceTr = pickTranslation(source.translations, currentLang);
+const entityLabel = sourceTr?.label ?? source.entity_type;
+```
+
+---
+
+## PARTE 7 — Frontend: sistema de filtros
+
+### 7.1 Leer toggles del módulo
+
+```typescript
+const visibleFilters = {
+  language: module.filter_language_enabled,
+  category: module.filter_category_enabled,
+  discount: module.filter_discount_enabled,
+  duration: module.filter_duration_enabled,
+  distance: module.filter_distance_enabled,
+};
+```
+
+Solo renderizar el control UI de un filtro si su boolean es `true`.
+
+### 7.2 Labels de filtros desde translations
+
+```typescript
+const moduleTr = pickTranslation(module.translations, currentLang);
+
+const filterLabels = {
+  language:  moduleTr?.filter_language_label  ?? 'Idioma',
+  category:  moduleTr?.filter_category_label  ?? 'Categoría',
+  discount:  moduleTr?.filter_discount_label  ?? 'Descuento',
+  duration:  moduleTr?.filter_duration_label  ?? 'Duración',
+  distance:  moduleTr?.filter_distance_label  ?? 'Distancia al centro',
+};
+```
+
+### 7.3 Apply button — estado pendiente
+
+Los filtros usan un patrón **pending → applied** para evitar cualquier hit al servidor mientras
+el usuario compone su selección. Sólo cuando hace click en "Aplicar" se actualizan los resultados.
+
+```typescript
+// Estado local del componente
+let pendingFilters = { ...defaultFilters };  // lo que el usuario está cambiando en la UI
+let activeFilters  = { ...defaultFilters };  // lo que realmente filtra la lista
+
+// Cada control de UI escribe sobre pendingFilters, NUNCA sobre activeFilters directamente.
+
+// Al hacer click en "Aplicar":
+function applyFilters() {
+  activeFilters = { ...pendingFilters };
+}
+
+// El label viene del CMS; fallback en cada idioma:
+const applyLabel = moduleTr?.filter_apply_label ?? 'Aplicar';
+```
+
+**Reglas:**
+- Los filtros **NO** se sincronizan con URL search params ni con ningún store que cause navegación.
+- Todo el estado vive en variables locales del componente (`let`).
+- El botón se renderiza sólo si hay al menos un filtro habilitado en el módulo.
+- Al limpiar/resetear filtros, se resetea `pendingFilters` y se llama `applyFilters()` en el mismo tick.
+
+### 7.4 Reference point label
+
+Mostrar `moduleTr?.reference_point_label` cerca del control de distancia.
+Ejemplo de valor: `"Medido desde Iglesia del Carmen, Vía España"`.
+
+### 7.5 Lógica de cada filtro
+
+Pipeline: `prefilter del módulo → filtros UI (AND entre filtros) → sort → corte max_items`
+
+```typescript
+// Filtro idioma — OR entre valores seleccionados
+if (activeFilters.language?.length) {
+  items = items.filter(item =>
+    activeFilters.language.some(lang => item.supported_language?.includes(lang))
+  );
+}
+
+// Filtro categoría — OR entre valores seleccionados
+if (activeFilters.category?.length) {
+  items = items.filter(item =>
+    activeFilters.category.some(cat => item.experience_category?.includes(cat))
+  );
+}
+
+// Filtro descuento — ítems con descuento >= N% (N=0 para "cualquier descuento")
+if (activeFilters.discountMin != null) {
+  items = items.filter(item =>
+    item.promo_discount_percent != null &&
+    item.promo_discount_percent >= activeFilters.discountMin
+  );
+}
+
+// Filtro duración — rango min/max
+if (activeFilters.durationMin != null || activeFilters.durationMax != null) {
+  items = items.filter(item => {
+    if (item.duration == null) return false;
+    if (activeFilters.durationMin != null && item.duration < activeFilters.durationMin) return false;
+    if (activeFilters.durationMax != null && item.duration > activeFilters.durationMax) return false;
+    return true;
+  });
+}
+
+// Filtro distancia — radio en km desde el centro
+if (activeFilters.distanceMaxKm != null) {
+  items = items.filter(item =>
+    item.distanceFromCenter != null &&
+    item.distanceFromCenter <= activeFilters.distanceMaxKm
+  );
+}
+```
+
+---
+
+## PARTE 8 — Frontend: sistema de sorting
+
+### 8.1 Opciones del selector
+
+| Valor interno | Label (fallback si falta CMS) | ASC/DESC |
+|---|---|---|
+| `relevance` | "Relevancia" | NO — sort fijo |
+| `discount_percent` | "Descuento" | SÍ |
+| `distance_from_center` | "Distancia al centro" | SÍ |
+| `duration` | "Duración" | SÍ |
+| `name` | "Nombre" | SÍ |
+
+### 8.2 Comparador
+
+```typescript
+type SortOption = 'relevance' | 'discount_percent' | 'distance_from_center' | 'duration' | 'name';
+type SortDir = 'asc' | 'desc';
+
+function sortItems(
+  items: NormalizedItem[],
+  sort: SortOption,
+  dir: SortDir
+): NormalizedItem[] {
+  const d = dir === 'asc' ? 1 : -1;
+
+  return [...items].sort((a, b) => {
+    switch (sort) {
+
+      case 'relevance':
+        // Comparador original de 4 niveles — no cambia con dir
+        if (b.priority !== a.priority) return b.priority - a.priority;
+        if ((b.promo_discount_percent ?? -1) !== (a.promo_discount_percent ?? -1))
+          return (b.promo_discount_percent ?? -1) - (a.promo_discount_percent ?? -1);
+        if ((b.recency ?? 0) !== (a.recency ?? 0))
+          return (b.recency ?? 0) - (a.recency ?? 0);
+        return a.stableKey.localeCompare(b.stableKey);
+
+      case 'discount_percent': {
+        // desc = mayor descuento primero; asc = menor primero; nulls siempre al final
+        const aVal = a.promo_discount_percent ?? (dir === 'asc' ? Infinity : -Infinity);
+        const bVal = b.promo_discount_percent ?? (dir === 'asc' ? Infinity : -Infinity);
+        return aVal !== bVal ? d * (bVal - aVal) : a.stableKey.localeCompare(b.stableKey);
+      }
+
+      case 'distance_from_center': {
+        // asc = más cerca primero; desc = más lejos primero; nulls siempre al final
+        const aVal = a.distanceFromCenter ?? Infinity;
+        const bVal = b.distanceFromCenter ?? Infinity;
+        return aVal !== bVal ? d * (aVal - bVal) : a.stableKey.localeCompare(b.stableKey);
+      }
+
+      case 'duration': {
+        const aVal = a.duration ?? (dir === 'asc' ? Infinity : -Infinity);
+        const bVal = b.duration ?? (dir === 'asc' ? Infinity : -Infinity);
+        return aVal !== bVal ? d * (aVal - bVal) : a.stableKey.localeCompare(b.stableKey);
+      }
+
+      case 'name': {
+        const cmp = (a.name ?? '').localeCompare(b.name ?? '', undefined, { sensitivity: 'base' });
+        return cmp !== 0 ? d * cmp : a.stableKey.localeCompare(b.stableKey);
+      }
+    }
+  });
+}
+```
+
+### 8.3 Aplicar corte max_items después del sort
+
+```typescript
+const filtered = applyFilters(normalizedItems, activeFilters);
+const sorted   = sortItems(filtered, activeSortOption, activeSortDir);
+const displayed = sorted.slice(0, module.max_items);
+```
+
+---
+
+## Checklist de implementación
+
+### Directus — ✅ SCHEMA Y SEED COMPLETOS
+- [x] Colección `stopover_mixed_experience_module_translations` creada con los 10 campos base
+- [x] Agregar a `stopover_mixed_experience_module_translations` los 7 campos nuevos:
+      `reference_point_label`, `filter_language_label`, `filter_category_label`,
+      `filter_discount_label`, `filter_duration_label`, `filter_distance_label`, `filter_apply_label`
+- [x] Colección `stopover_mixed_experience_module_sources` creada con `entity_type`, `max_items`, `status`, `module_id`
+- [x] Crear `stopover_mixed_experience_module_sources_translations` (`label` + relaciones + alias `translations` en sources)
+- [x] Agregar 5 booleans `filter_*_enabled` a `stopover_mixed_experience_module` (default true, not null)
+- [x] Cargar traducciones iniciales en `sources_translations` con los labels hardcodeados actuales (6 rows)
+- [x] Contenido de texto existente ya vive en `module_translations` (no requiere migración)
+- [ ] Cargar valores editoriales para `filter_*_label`, `filter_apply_label`, `reference_point_label` en en/es/pt (pendiente de editor)
+
+### Frontend
+- [ ] Actualizar Zod schema `src/lib/directus/stopover_mixed_experience_module.ts`
+      con los campos nuevos de translations y los 5 booleans del módulo
+- [ ] Actualizar query de Directus: agregar `translations.*` y `sources.translations.*`
+      (en `+page.server.ts` `buildMixedConfigQuery` y en `utils.ts` `getMixedModuleDetailsByKey` / `getFirstMixedModule`)
+- [ ] Agregar al query de items (`buildMixedPromoItemsQuery` y `buildMixedSourceItemsQuery`) los campos:
+      `duration`, `meeting_point` / `location`, `supported_languages`, `experience_category`, `date_created`, `id`
+- [ ] Agregar helper `pickTranslation`
+- [ ] Normalización: `meeting_point` / `location` → `geoPoint` (ambos son `GeoJSON`, extraer coords)
+- [ ] Normalización: `duration` → siempre `number` (tours ya es number, places viene como string)
+- [ ] Normalización: calcular `distanceFromCenter` con haversine (ref Iglesia del Carmen)
+- [ ] Normalización: `stableKey = "${_collection}:${id}"`
+- [ ] Normalización: reemplazar label hardcodeado de entity type (en componente svelte, líneas 85-105)
+      por `source.translations[lang].label`
+- [ ] Filtros: leer `filter_*_enabled` del módulo → mostrar/ocultar cada control
+- [ ] Filtros: leer `filter_*_label` desde translations → labels de UI
+- [ ] Filtros: mostrar `reference_point_label` junto al control de distancia
+- [ ] Filtros: patrón pending → applied con botón "Aplicar" (sin hits al servidor)
+- [ ] Filtros: `filter_apply_label` desde translations (fallback: "Aplicar" / "Apply")
+- [ ] Filtros: implementar los 5 filtros con lógica AND/OR
+- [ ] Sort: agregar selector con 5 opciones (ASC/DESC donde aplica, no en relevance)
+- [ ] Sort: implementar función `sortItems`
+- [ ] Sort: aplicar caps — primero `source.max_items` por colección, luego `module.max_items` global después del sort
+
+---
+
+## Notas para Cursor
+
+- Componente principal: `src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte`.
+- Merge engine vive en `src/routes/[...path]/+page.server.ts` y `src/routes/utils.ts`.
+- `stableKey` se genera durante la normalización: `"stopover_tour:${item.id}"` o `"stopover_place_to_visit:${item.id}"` (usar el campo `_collection` que ya se inyecta en el merge).
+- `recency` en el comparador de relevance usa `date_created`. Ambas colecciones lo tienen disponible.
+- `geoPoint` viene como `GeoJSON` confirmado: `{ type: "Point", coordinates: [lng, lat] }`.
+  En `haversineKm`, extraer coords así: `lng = geoPoint.coordinates[0]`, `lat = geoPoint.coordinates[1]`.
+- Para el filtro de distancia: si el usuario no seleccionó ningún radio, no filtrar
+  (`distanceFromCenter` calculado pero filtro inactivo).
+- Caps por source (`sources.max_items`): el campo YA EXISTE en la colección sources.
+  Aplicarlo antes de mezclar; si el cap es null, no aplicar cap individual.
+- `experience_category` es `number | null` (M2O), NO multi-select. El filtro debe comparar por ID
+  (ej. `activeFilters.category.includes(item.experience_category)`).
+- `duration` requiere parseo: en `stopover_tour` viene como `number`, en `stopover_place_to_visit`
+  viene como `string`. Normalizar con `Number(item.duration) || null`.

--- a/docs/mixed-experience-module.md
+++ b/docs/mixed-experience-module.md
@@ -1,0 +1,158 @@
+# Mixed Experience Module — Activities & Tours Merge
+
+> Commit: `03885f5` — `feat: merge tour and activities part 1 ready to review`
+
+## Overview
+
+The **Mixed Experience Module** (`stopover_mixed_experience_module`) is a new Directus-backed content block that replaces the need for separate activity and tour modules. It allows CMS editors to curate a single card grid sourced from **any combination** of entity types: activities, tours, hotels, restaurants, packages, and transportation.
+
+The module renders using the `PromoShow` card component, with an optional entity-type badge ("Tour" / "Activity" / "Actividad" / etc.) that is inferred automatically from the source collection.
+
+---
+
+## What Changed
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `src/lib/directus/stopover_mixed_experience_module.ts` | Zod schema + type exports for the new module |
+| `src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte` | Svelte component that renders the card grid |
+| `src/lib/components/directus/general-components/mixed-experience-module/index.ts` | Barrel export |
+
+### Modified files
+
+| File | What changed |
+|------|-------------|
+| `src/routes/[...path]/+page.server.ts` | Added mixed-module detection + multi-collection item fetching |
+| `src/routes/utils.ts` | Extended collection aliases, added shared sort logic, added mixed module support |
+| `src/lib/directus/section.ts` | Added mixed module to section content schema |
+| `src/lib/directus/content-group.ts` | Added mixed module to content group schema |
+| `src/lib/directus/stopover_hotel_module.ts` | Minor cleanup |
+| `src/lib/components/directus/utils.ts` | Shared utility additions |
+| `src/lib/components/site/navigation/home/navigation-home.svelte` | UI fix for home navigation |
+
+---
+
+## Directus Schema
+
+The CMS collection is `stopover_mixed_experience_module` (also tolerates the legacy typo variant `stopover_mixed_experiece_module`).
+
+```
+stopover_mixed_experience_module
+├── key                   string (required)
+├── max_items             number
+├── prefilter             string | null  →  "promotions" to show only discounted items
+├── sources[]
+│   ├── entity_type       string  →  e.g. "activities", "tours", "hotels"
+│   └── item              number | string | object | null
+└── translations[]
+    ├── languages_code
+    ├── title
+    ├── description
+    ├── disclaimer_text
+    ├── primary_cta_label
+    ├── primary_cta_url
+    ├── secondary_cta_label
+    └── secondary_cta_url
+```
+
+### `entity_type` accepted values
+
+The following values (and their aliases) are all resolved to the correct Directus collection:
+
+| `entity_type` value | Resolves to |
+|---------------------|-------------|
+| `activities`, `activity`, `stopover_place_to_visit`, `stopover_activity` | `stopover_place_to_visit` |
+| `tours`, `tour`, `stopover_tour`, `stopover_tours` | `stopover_tour` |
+| `hotels`, `hotel`, `stopover_hotel`, `stopover_hotels` | `stopover_hotels` |
+| `restaurants`, `restaurant`, `stopover_restaurant`, `stopover_restaurants` | `stopover_restaurants` |
+| `packages`, `package`, `stopover_package`, `stopover_packages` | `stopover_package` |
+| `transportation`, `transport`, `stopover_transportation`, `stopover_transport` | `stopover_transportation` |
+
+---
+
+## Data Flow
+
+```
++page.server.ts
+  └── getModulesConfigList(sections)
+        ↓ Finds all stopover_mixed_experience_module entries in sections/content-groups
+  └── For each mixed module:
+        └── Reads sources[].entity_type
+        └── Queries each collection via buildMixedPromoItemsQuery()
+              ↓ Fields: priority, main_image, promo_discount_*, translations, parent_page
+        └── Merges items from all sources
+        └── Sorts merged list via comparePromoItems()
+        └── Trims to max_items
+  └── Passes result to $page.data.mixed_items_query_output
+
+mixed-experience-module.svelte
+  └── Reads $page.data.mixed_items_query_output.sorted_items
+  └── Renders PromoShow card per item
+  └── Infers entity-type badge from promo._collection
+  └── Renders primary / secondary CTAs from module translations
+```
+
+---
+
+## Sorting Logic
+
+Items from all sources are merged and sorted by the following criteria (in order):
+
+1. **Priority** — higher number wins (`priority DESC`)
+2. **Promo discount percent** — higher discount wins (`promo_discount_percent DESC`)
+3. **Date created** — older items ranked first (`date_created ASC`) — "antiguedad"
+4. **Name** — alphabetical fallback (`name ASC`, locale-aware)
+
+```ts
+// src/routes/utils.ts
+const comparePromoItems = (a, b) => {
+  byPriority → byDiscountPercent → byDate → byName
+};
+```
+
+---
+
+## Prefilter: Promotions Mode
+
+When `prefilter` is set to `"promotions"` (case-insensitive), the module only fetches items that have at least one of:
+
+- `promo_discount_amount` set
+- `promo_discount_percent` set
+- `promo_code` set
+
+---
+
+## Entity Type Badge
+
+The `getEntityTypeLabel()` function in the Svelte component maps a collection name to a localised label shown on the card:
+
+| Locale | Tour label | Activity label |
+|--------|-----------|----------------|
+| `en` | Tour | Activity |
+| `es` | Tour | Actividad |
+| `pt` | Tour | Atividade |
+
+The badge only appears when the item also has a promo discount displayed.
+
+---
+
+## CMS Setup Checklist
+
+When creating a new `stopover_mixed_experience_module` in Directus:
+
+- [ ] Add the module to a **section** (`section_content`) or to a **content group** (`content_group.content`)
+- [ ] Configure at least one entry in `sources[]` with the correct `entity_type`
+- [ ] Set `max_items` (recommended: 4–8)
+- [ ] Set `prefilter` to `"promotions"` if the block should only show discounted items
+- [ ] Add translations for each language (at minimum title + one CTA pair)
+- [ ] Verify that the referenced entities have `parent_page` set (required for card links to work)
+
+---
+
+## Known Limitations / Next Steps
+
+- **Part 1 only**: The current implementation fetches items but does not yet support inline item pinning from the CMS (`sources[].item` is typed but not consumed).
+- The legacy typo variant `stopover_mixed_experiece_module` is supported as a fallback — this alias should be removed once the CMS collection is fully migrated.
+- Sort by discount amount (`promo_discount_amount`) is not yet part of the primary sort key; only `promo_discount_percent` is considered.

--- a/src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte
+++ b/src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte
@@ -14,7 +14,6 @@
 	import { getPathRecursive } from '$lib/i18n/cannonicals';
 	import { isNotNil, map, replace } from 'ramda';
 	import { getDirectusImage } from '../../stopover/utils';
-	import { cn } from '$lib/utils';
 	import {
 		applyFilters,
 		applySourceCaps,
@@ -217,10 +216,10 @@
 		distance: moduleConfig?.filter_distance_enabled ?? true
 	};
 
-	// Category is shown as immediate-apply chips above the grid (not inside the modal).
-	// The modal only handles language, discount, duration, and distance.
+	// Only render filter UI if at least one filter is enabled AND has facets worth showing.
 	const hasAnyFilter =
 		(filterToggles.language && availableLanguages.length > 0) ||
+		(filterToggles.category && availableCategories.length > 0) ||
 		filterToggles.discount ||
 		filterToggles.duration ||
 		filterToggles.distance;
@@ -389,15 +388,6 @@
 		};
 	}
 
-	// Category chips apply immediately (bypass modal pending/apply flow)
-	function toggleCategoryImmediate(id: number) {
-		const next = activeFilters.categories.includes(id)
-			? activeFilters.categories.filter((c) => c !== id)
-			: [...activeFilters.categories, id];
-		activeFilters = { ...activeFilters, categories: next };
-		pendingFilters = { ...pendingFilters, categories: next };
-	}
-
 	// Discount slider → pendingFilters (0 = no filter)
 	$: {
 		const next = discountSliderValue > 0 ? discountSliderValue : null;
@@ -435,7 +425,7 @@
 	function countActive(filters: MixedFilterState): number {
 		let n = 0;
 		if (filters.languages.length > 0) n++;
-		// categories are counted separately (shown as chips outside the modal)
+		if (filters.categories.length > 0) n++;
 		if (filters.discountMin != null) n++;
 		if (filters.durationMin != null || filters.durationMax != null) n++;
 		if (filters.distanceMaxKm != null) n++;
@@ -498,30 +488,8 @@
 </script>
 
 <div data-items-count={displayedItems.length}>
-	<!-- Category chips: always-visible multi-select above the grid -->
-	{#if filterToggles.category && availableCategories.length > 0 && normalizedPool.length > 0}
-		<nav aria-label={filterLabels.category} class="mb-4 mt-4 flex flex-wrap gap-2">
-			{#each availableCategories as cat (cat.id)}
-				{@const isSelected = activeFilters.categories.includes(cat.id)}
-				<button
-					type="button"
-					aria-pressed={isSelected}
-					onclick={() => toggleCategoryImmediate(cat.id)}
-					class={cn(
-						'rounded-full border px-4 py-1 text-d1 transition-colors',
-						isSelected
-							? 'border-primary bg-primary text-common-white'
-							: 'border-grey-300 bg-common-white text-grey-700 hover:border-primary hover:text-primary'
-					)}
-				>
-					{cat.label}
-				</button>
-			{/each}
-		</nav>
-	{/if}
-
 	{#if hasAnyFilter && normalizedPool.length > 0}
-		<div class="mb-4 mt-2 flex justify-end py-1">
+		<div class="mb-4 mt-4 flex justify-end py-1">
 			<div class="flex items-center gap-2">
 				<button
 					type="button"
@@ -613,6 +581,40 @@
 						</div>
 					</fieldset>
 				{/if}
+
+			<!-- Category (multi-select listbox with checkboxes) -->
+			{#if filterToggles.category && availableCategories.length > 0}
+				<fieldset class="flex flex-col gap-2">
+					<legend class="mb-1 text-d1 font-medium text-grey-700">
+						{filterLabels.category}
+					</legend>
+					<div
+						role="listbox"
+						aria-multiselectable="true"
+						aria-label={filterLabels.category}
+						class="max-h-44 overflow-y-auto rounded-lg border border-grey-300 bg-common-white"
+					>
+						{#each availableCategories as cat (cat.id)}
+							{@const isChecked = pendingFilters.categories.includes(cat.id)}
+							<label
+								class="flex cursor-pointer select-none items-center gap-3 px-3 py-2.5 transition-colors hover:bg-background-lightblue {isChecked ? 'bg-background-lightblue' : ''}"
+							>
+								<Checkbox
+									checked={isChecked}
+									onCheckedChange={() => toggleCategory(cat.id)}
+								/>
+								<span class="text-b text-grey-700">{cat.label}</span>
+							</label>
+						{/each}
+					</div>
+					{#if pendingFilters.categories.length > 0}
+						<p class="text-d3 text-grey-500">
+							{pendingFilters.categories.length}
+							{pendingFilters.categories.length === 1 ? 'seleccionada' : 'seleccionadas'}
+						</p>
+					{/if}
+				</fieldset>
+			{/if}
 
 			<!-- Discount (slider, step 5) -->
 				{#if filterToggles.discount}

--- a/src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte
+++ b/src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte
@@ -216,10 +216,12 @@
 		distance: moduleConfig?.filter_distance_enabled ?? true
 	};
 
-	// Only render filter UI if at least one filter is enabled AND has facets worth showing.
+	// Only render filter UI if at least one filter is enabled.
+	// Category shows even with 0 items (displays an empty-state message) so it's
+	// always reachable for debugging while Directus data is being populated.
 	const hasAnyFilter =
 		(filterToggles.language && availableLanguages.length > 0) ||
-		(filterToggles.category && availableCategories.length > 0) ||
+		filterToggles.category ||
 		filterToggles.discount ||
 		filterToggles.duration ||
 		filterToggles.distance;
@@ -523,6 +525,46 @@
 			onSecondaryAction={resetAll}
 		>
 			<div class="flex flex-col gap-6">
+				<!-- Category (multi-select listbox – first for visibility) -->
+				{#if filterToggles.category}
+					<fieldset class="flex flex-col gap-2">
+						<legend class="mb-1 text-d1 font-medium text-grey-700">
+							{filterLabels.category}
+						</legend>
+						{#if availableCategories.length > 0}
+							<div
+								role="listbox"
+								aria-multiselectable="true"
+								aria-label={filterLabels.category}
+								class="max-h-44 overflow-y-auto rounded-lg border border-grey-300 bg-common-white"
+							>
+								{#each availableCategories as cat (cat.id)}
+									{@const isChecked = pendingFilters.categories.includes(cat.id)}
+									<label
+										class="flex cursor-pointer select-none items-center gap-3 px-3 py-2.5 transition-colors hover:bg-background-lightblue {isChecked ? 'bg-background-lightblue' : ''}"
+									>
+										<Checkbox
+											checked={isChecked}
+											onCheckedChange={() => toggleCategory(cat.id)}
+										/>
+										<span class="text-b text-grey-700">{cat.label}</span>
+									</label>
+								{/each}
+							</div>
+							{#if pendingFilters.categories.length > 0}
+								<p class="text-d3 text-grey-500">
+									{pendingFilters.categories.length}
+									{pendingFilters.categories.length === 1 ? 'seleccionada' : 'seleccionadas'}
+								</p>
+							{/if}
+						{:else}
+							<p class="text-d3 text-grey-400 italic">
+								Sin categorías disponibles — asigna <code>experience_category</code> en Directus.
+							</p>
+						{/if}
+					</fieldset>
+				{/if}
+
 				<!-- Sort section -->
 				<div>
 					<p class="mb-2 text-d1 font-medium text-grey-700">{filterLabels.sort}</p>
@@ -581,40 +623,6 @@
 						</div>
 					</fieldset>
 				{/if}
-
-			<!-- Category (multi-select listbox with checkboxes) -->
-			{#if filterToggles.category && availableCategories.length > 0}
-				<fieldset class="flex flex-col gap-2">
-					<legend class="mb-1 text-d1 font-medium text-grey-700">
-						{filterLabels.category}
-					</legend>
-					<div
-						role="listbox"
-						aria-multiselectable="true"
-						aria-label={filterLabels.category}
-						class="max-h-44 overflow-y-auto rounded-lg border border-grey-300 bg-common-white"
-					>
-						{#each availableCategories as cat (cat.id)}
-							{@const isChecked = pendingFilters.categories.includes(cat.id)}
-							<label
-								class="flex cursor-pointer select-none items-center gap-3 px-3 py-2.5 transition-colors hover:bg-background-lightblue {isChecked ? 'bg-background-lightblue' : ''}"
-							>
-								<Checkbox
-									checked={isChecked}
-									onCheckedChange={() => toggleCategory(cat.id)}
-								/>
-								<span class="text-b text-grey-700">{cat.label}</span>
-							</label>
-						{/each}
-					</div>
-					{#if pendingFilters.categories.length > 0}
-						<p class="text-d3 text-grey-500">
-							{pendingFilters.categories.length}
-							{pendingFilters.categories.length === 1 ? 'seleccionada' : 'seleccionadas'}
-						</p>
-					{/if}
-				</fieldset>
-			{/if}
 
 			<!-- Discount (slider, step 5) -->
 				{#if filterToggles.discount}

--- a/src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte
+++ b/src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte
@@ -1,76 +1,480 @@
-<script lang="ts">
+﻿<script lang="ts">
 	import { page } from '$app/stores';
 	import { PromoShow } from '$lib/components/ui/cards/promo-show';
 	import KeyboardArrowRight from '$lib/components/ui/icon/keyboard-arrow-right.svelte';
-	import { Button } from '$ui/components/button';
+	import { Button, buttonVariants } from '$ui/components/button';
+	import { Checkbox } from '$ui/components/checkbox';
+	import { Select } from '$ui/components/select';
+	import { Regular } from '$ui/components/icon';
+	import { Slider } from '$ui/components/slider';
+	import { RadioGroup, RadioItem } from '$ui/components/radio';
+	import { Modal } from '$ui/components/modal';
 	import type { PathSchema } from '$lib/domain/pages';
 	import type { StopoverMixedExperienceModuleSchema } from '$lib/directus/stopover_mixed_experience_module';
 	import { getPathRecursive } from '$lib/i18n/cannonicals';
-	import { isNil, isNotNil, map, replace } from 'ramda';
+	import { isNotNil, map, replace } from 'ramda';
 	import { getDirectusImage } from '../../stopover/utils';
-
-	type MixedPromoItem = {
-		priority?: number | null;
-		date_created?: string | null;
-		main_image?: string | null;
-		promo_discount_percent?: number | null;
-		promo_discount_amount?: number | null;
-		_collection?: string | null;
-		translations?: Array<{
-			name?: string | null;
-			path?: string | null;
-			promo_name?: string | null;
-		}>;
-		parent_page?: PathSchema | null;
-	};
+	import {
+		applyFilters,
+		applySourceCaps,
+		emptyFilterState,
+		getLanguageDisplayName,
+		normalizeMixedItem,
+		pickTranslation,
+		sortItems,
+		type MixedFilterState,
+		type NormalizedMixedItem,
+		type RawMixedItem,
+		type SortDir,
+		type SortOption
+	} from './utils';
 
 	type MixedModuleTranslation = {
+		languages_code?: string | null;
+		title?: string | null;
+		description?: string | null;
 		primary_cta_label?: string | null;
 		primary_cta_url?: string | null;
 		secondary_cta_label?: string | null;
 		secondary_cta_url?: string | null;
+		reference_point_label?: string | null;
+		filter_language_label?: string | null;
+		filter_category_label?: string | null;
+		filter_discount_label?: string | null;
+		filter_duration_label?: string | null;
+		filter_distance_label?: string | null;
+		filter_apply_label?: string | null;
 	};
 
 	type MixedQueryEntry = {
 		collection?: string | null;
-		items?: MixedPromoItem[];
+		items?: RawMixedItem[];
+	};
+
+	type MixedSourceTranslation = {
+		languages_code?: string | null;
+		label?: string | null;
+	};
+
+	type MixedSource = {
+		id?: number;
+		entity_type?: string | null;
+		max_items?: number | null;
+		status?: string | null;
+		translations?: MixedSourceTranslation[] | null;
 	};
 
 	export let item: StopoverMixedExperienceModuleSchema | null = null;
 
+	const locale = $page.data.locale || 'en';
 	const mixedItemsQueryOutput = $page.data.mixed_items_query_output;
-	const sortedItemsFromQuery: MixedPromoItem[] = Array.isArray(mixedItemsQueryOutput?.sorted_items)
-		? (mixedItemsQueryOutput.sorted_items as MixedPromoItem[])
-		: [];
-	const itemsQueryEntries: MixedQueryEntry[] = Array.isArray(mixedItemsQueryOutput?.queries)
-		? (mixedItemsQueryOutput.queries as MixedQueryEntry[])
-		: [];
 
-	const moduleItems: MixedPromoItem[] =
-		sortedItemsFromQuery.length > 0
-			? sortedItemsFromQuery
-			: itemsQueryEntries.flatMap((entry) =>
-					Array.isArray(entry?.items)
-						? entry.items.map((promo) => ({
-								...promo,
-								_collection: promo._collection ?? entry.collection ?? null
-							}))
-						: []
-				);
+	// ---------------------------------------------------------------------------
+	// Read module config (translations, sources with labels, filter_*_enabled)
+	// ---------------------------------------------------------------------------
+	const moduleConfigFromQuery: StopoverMixedExperienceModuleSchema | null = Array.isArray(
+		$page.data.mixed_experience_module_query
+	)
+		? (($page.data.mixed_experience_module_query as StopoverMixedExperienceModuleSchema[])?.[0] ??
+			null)
+		: null;
+	const moduleConfig: StopoverMixedExperienceModuleSchema | null = item ?? moduleConfigFromQuery;
 
+	// pickTranslation matches the user's active locale (with 'en' fallback and
+	// final fallback to translations[0]) instead of blindly taking translations[0].
 	const moduleTranslation: MixedModuleTranslation | null =
-		(item?.translations?.[0] as MixedModuleTranslation | undefined) ??
-		(Array.isArray($page.data.mixed_experience_module_query)
-			? (($page.data.mixed_experience_module_query?.[0]?.translations?.[0] as
-					| MixedModuleTranslation
-					| undefined) ?? null)
-			: null);
+		pickTranslation(
+			moduleConfig?.translations as MixedModuleTranslation[] | null | undefined,
+			locale
+		) ?? null;
 
+	const moduleSources: MixedSource[] = Array.isArray(moduleConfig?.sources)
+		? (moduleConfig!.sources as MixedSource[])
+		: [];
+
+	// ---------------------------------------------------------------------------
+	// Entity type label lookup (from sources.translations[lang].label, with
+	// fallback to hardcoded values for backwards compatibility)
+	// ---------------------------------------------------------------------------
+	const fallbackLabels = {
+		en: { tour: 'Tour', activity: 'Activity' },
+		es: { tour: 'Tour', activity: 'Actividad' },
+		pt: { tour: 'Tour', activity: 'Atividade' }
+	};
+
+	function entityTypeMatchesCollection(
+		entityType: string | null | undefined,
+		collection: string
+	): boolean {
+		if (!entityType) return false;
+		const et = entityType.toLowerCase();
+		const col = collection.toLowerCase();
+		if (et === col) return true;
+		if (col === 'stopover_tour' && (et === 'stopover_tours' || et === 'tour' || et === 'tours'))
+			return true;
+		if (
+			col === 'stopover_place_to_visit' &&
+			(et === 'stopover_places_to_visit' ||
+				et === 'stopover_activity' ||
+				et === 'stopover_activities' ||
+				et === 'activity' ||
+				et === 'activities')
+		)
+			return true;
+		return false;
+	}
+
+	function getEntityTypeLabel(collection: string | null | undefined): string {
+		if (!collection) return '';
+		const matchedSource = moduleSources.find((source) =>
+			entityTypeMatchesCollection(source.entity_type, collection)
+		);
+		const cmsLabel = pickTranslation(matchedSource?.translations ?? [], locale)?.label;
+		if (cmsLabel) return cmsLabel;
+		const localizedLabels =
+			fallbackLabels[locale as keyof typeof fallbackLabels] || fallbackLabels.en;
+		const normalized = collection.toLowerCase();
+		if (normalized.includes('tour')) return localizedLabels.tour;
+		if (
+			normalized.includes('place_to_visit') ||
+			normalized.includes('activity') ||
+			normalized.includes('activities')
+		)
+			return localizedLabels.activity;
+		return '';
+	}
+
+	// ---------------------------------------------------------------------------
+	// Normalize the full pool of items
+	// ---------------------------------------------------------------------------
+	const rawPool: RawMixedItem[] = (() => {
+		const fromSortedItems: RawMixedItem[] = Array.isArray(mixedItemsQueryOutput?.sorted_items)
+			? (mixedItemsQueryOutput.sorted_items as RawMixedItem[])
+			: [];
+		if (fromSortedItems.length > 0) return fromSortedItems;
+
+		const entries: MixedQueryEntry[] = Array.isArray(mixedItemsQueryOutput?.queries)
+			? (mixedItemsQueryOutput.queries as MixedQueryEntry[])
+			: [];
+		return entries.flatMap((entry) =>
+			Array.isArray(entry?.items)
+				? entry.items.map((promo) => ({
+						...promo,
+						_collection: promo._collection ?? entry.collection ?? null
+					}))
+				: []
+		);
+	})();
+
+	const normalizedPool: NormalizedMixedItem[] = rawPool.map(normalizeMixedItem);
+
+	// ---------------------------------------------------------------------------
+	// Derive filter facets from the pool (which values to offer in UI)
+	// ---------------------------------------------------------------------------
+	type LanguageFacet = { code: string; label: string };
+	type CategoryFacet = { id: number; label: string };
+
+	const availableLanguages: LanguageFacet[] = (() => {
+		const codes = Array.from(new Set(normalizedPool.flatMap((i) => i.supportedLanguages))).sort();
+		return codes.map((code) => ({ code, label: getLanguageDisplayName(code, locale) }));
+	})();
+
+	const availableCategories: CategoryFacet[] = (() => {
+		const byId = new Map<number, string>();
+		for (const item of normalizedPool) {
+			if (typeof item.experienceCategory !== 'number') continue;
+			const existing = byId.get(item.experienceCategory);
+			// Prefer a non-empty localized label over a missing one
+			if (!existing && item.categoryLabel) {
+				byId.set(item.experienceCategory, item.categoryLabel);
+			} else if (!byId.has(item.experienceCategory)) {
+				byId.set(item.experienceCategory, item.categoryLabel ?? `#${item.experienceCategory}`);
+			}
+		}
+		return Array.from(byId.entries())
+			.map(([id, label]) => ({ id, label }))
+			.sort((a, b) => a.label.localeCompare(b.label, locale, { sensitivity: 'base' }));
+	})();
+
+	// Preset duration and distance options — can be refined later from the CMS.
+	const durationPresets: Array<{ label: string; min: number | null; max: number | null }> = [
+		{ label: '< 2h', min: null, max: 2 },
+		{ label: '2–4h', min: 2, max: 4 },
+		{ label: '4–8h', min: 4, max: 8 },
+		{ label: '> 8h', min: 8, max: null }
+	];
+	const distancePresets: number[] = [1, 3, 5, 10, 20];
+
+	// ---------------------------------------------------------------------------
+	// Filter toggles from the module
+	// ---------------------------------------------------------------------------
+	const filterToggles = {
+		language: moduleConfig?.filter_language_enabled ?? true,
+		category: moduleConfig?.filter_category_enabled ?? true,
+		discount: moduleConfig?.filter_discount_enabled ?? true,
+		duration: moduleConfig?.filter_duration_enabled ?? true,
+		distance: moduleConfig?.filter_distance_enabled ?? true
+	};
+
+	// Only render filter UI if at least one filter is enabled AND has facets worth showing.
+	const hasAnyFilter =
+		(filterToggles.language && availableLanguages.length > 0) ||
+		(filterToggles.category && availableCategories.length > 0) ||
+		filterToggles.discount ||
+		filterToggles.duration ||
+		filterToggles.distance;
+
+	// ---------------------------------------------------------------------------
+	// Filter labels
+	//
+	// Labels marked [CMS] are sourced from the module's translation row matching
+	// the current locale (stopover_mixed_experience_module_translations). Edit
+	// them directly in the CMS under the module's "Translations" tab.
+	//
+	// Labels marked [HARDCODED] have no corresponding field in the CMS schema
+	// yet; they fall back to the locale-keyed table below. To make them CMS-
+	// editable, add the field to stopover_mixed_experience_module_translations
+	// via the Directus API (see .ai/scripts/add-translation-fields.ps1 as
+	// reference), add it to stopoverMixedExperienceTranslationSchema and
+	// stopoverMixedExperienceModuleQueryFields in
+	// src/lib/directus/stopover_mixed_experience_module.ts, and wire it in the
+	// filterLabels object below.
+	// ---------------------------------------------------------------------------
+	const defaultFilterLabels = {
+		en: {
+			filters: 'Filters',
+			language: 'Language',
+			category: 'Category',
+			discount: 'Discount',
+			duration: 'Duration',
+			distance: 'Distance',
+			apply: 'Apply',
+			reset: 'Reset',
+			referencePoint: '',
+			sort: 'Sort by',
+			sortDir: 'Order',
+			sortAsc: 'Ascending',
+			sortDesc: 'Descending',
+			anyDuration: 'Any',
+			anyDistance: 'Any'
+		},
+		es: {
+			filters: 'Filtros',
+			language: 'Idioma',
+			category: 'Categoría',
+			discount: 'Descuento',
+			duration: 'Duración',
+			distance: 'Distancia',
+			apply: 'Aplicar',
+			reset: 'Limpiar',
+			referencePoint: '',
+			sort: 'Ordenar por',
+			sortDir: 'Orden',
+			sortAsc: 'Ascendente',
+			sortDesc: 'Descendente',
+			anyDuration: 'Cualquiera',
+			anyDistance: 'Cualquiera'
+		},
+		pt: {
+			filters: 'Filtros',
+			language: 'Idioma',
+			category: 'Categoria',
+			discount: 'Desconto',
+			duration: 'Duração',
+			distance: 'Distância',
+			apply: 'Aplicar',
+			reset: 'Limpar',
+			referencePoint: '',
+			sort: 'Ordenar por',
+			sortDir: 'Ordem',
+			sortAsc: 'Crescente',
+			sortDesc: 'Decrescente',
+			anyDuration: 'Qualquer',
+			anyDistance: 'Qualquer'
+		}
+	};
+	const fallbackFilterLabels =
+		defaultFilterLabels[locale as keyof typeof defaultFilterLabels] || defaultFilterLabels.en;
+
+	const filterLabels = {
+		filters: fallbackFilterLabels.filters,                                          // [HARDCODED]
+		language: moduleTranslation?.filter_language_label || fallbackFilterLabels.language,   // [CMS] filter_language_label
+		category: moduleTranslation?.filter_category_label || fallbackFilterLabels.category,   // [CMS] filter_category_label
+		discount: moduleTranslation?.filter_discount_label || fallbackFilterLabels.discount,   // [CMS] filter_discount_label
+		duration: moduleTranslation?.filter_duration_label || fallbackFilterLabels.duration,   // [CMS] filter_duration_label
+		distance: moduleTranslation?.filter_distance_label || fallbackFilterLabels.distance,   // [CMS] filter_distance_label
+		apply: moduleTranslation?.filter_apply_label || fallbackFilterLabels.apply,            // [CMS] filter_apply_label
+		reset: fallbackFilterLabels.reset,                                              // [HARDCODED]
+		referencePoint: moduleTranslation?.reference_point_label || '',                 // [CMS] reference_point_label
+		sort: fallbackFilterLabels.sort,                                                // [HARDCODED]
+		sortDir: fallbackFilterLabels.sortDir,                                          // [HARDCODED]
+		sortAsc: fallbackFilterLabels.sortAsc,                                          // [HARDCODED]
+		sortDesc: fallbackFilterLabels.sortDesc,                                        // [HARDCODED]
+		anyDuration: fallbackFilterLabels.anyDuration,                                  // [HARDCODED]
+		anyDistance: fallbackFilterLabels.anyDistance                                   // [HARDCODED]
+	};
+
+	const sortOptionLabels: Record<SortOption, string> = {
+		relevance: locale === 'es' ? 'Relevancia' : locale === 'pt' ? 'Relevância' : 'Relevance',
+		discount_percent: filterLabels.discount,
+		distance_from_center: filterLabels.distance,
+		duration: filterLabels.duration,
+		name: locale === 'es' ? 'Nombre' : locale === 'pt' ? 'Nome' : 'Name'
+	};
+	const sortOptionOrder: SortOption[] = [
+		'relevance',
+		'discount_percent',
+		'distance_from_center',
+		'duration',
+		'name'
+	];
+	const sortSelectOptions = sortOptionOrder.map((opt) => ({
+		value: opt,
+		label: sortOptionLabels[opt]
+	}));
+
+	// ---------------------------------------------------------------------------
+	// Pending → applied filter state pattern (no server hits on change)
+	// ---------------------------------------------------------------------------
+	let pendingFilters: MixedFilterState = emptyFilterState();
+	let activeFilters: MixedFilterState = emptyFilterState();
+	let pendingSort: SortOption = 'relevance';
+	let activeSort: SortOption = 'relevance';
+	let pendingSortDir: SortDir = 'desc';
+	let activeSortDir: SortDir = 'desc';
+	let pendingDurationPreset: string | null = null;
+	let pendingDistancePreset: number | null = null;
+	let modalOpen = false;
+	let discountSliderValue: number = 0;
+	let durationRadioValue: string = 'any';
+	let distanceRadioValue: string = 'any';
+
+	function applyAll() {
+		activeFilters = { ...pendingFilters };
+		activeSort = pendingSort;
+		activeSortDir = pendingSortDir;
+		modalOpen = false;
+	}
+
+	function resetAll() {
+		pendingFilters = emptyFilterState();
+		pendingSort = 'relevance';
+		pendingSortDir = 'desc';
+		pendingDurationPreset = null;
+		durationRadioValue = 'any';
+		pendingDistancePreset = null;
+		distanceRadioValue = 'any';
+		discountSliderValue = 0;
+		activeFilters = emptyFilterState();
+		activeSort = 'relevance';
+		activeSortDir = 'desc';
+	}
+
+	function toggleLanguage(code: string) {
+		pendingFilters = {
+			...pendingFilters,
+			languages: pendingFilters.languages.includes(code)
+				? pendingFilters.languages.filter((c) => c !== code)
+				: [...pendingFilters.languages, code]
+		};
+	}
+
+	function toggleCategory(id: number) {
+		pendingFilters = {
+			...pendingFilters,
+			categories: pendingFilters.categories.includes(id)
+				? pendingFilters.categories.filter((c) => c !== id)
+				: [...pendingFilters.categories, id]
+		};
+	}
+
+	// Discount slider → pendingFilters (0 = no filter)
+	$: {
+		const next = discountSliderValue > 0 ? discountSliderValue : null;
+		if (next !== pendingFilters.discountMin) {
+			pendingFilters = { ...pendingFilters, discountMin: next };
+		}
+	}
+
+	// Duration radio → pendingFilters
+	$: {
+		const expectedPreset = durationRadioValue === 'any' ? null : durationRadioValue;
+		if (expectedPreset !== pendingDurationPreset) {
+			pendingDurationPreset = expectedPreset;
+			const match =
+				expectedPreset === null
+					? null
+					: durationPresets.find((p) => p.label === durationRadioValue);
+			pendingFilters = {
+				...pendingFilters,
+				durationMin: match?.min ?? null,
+				durationMax: match?.max ?? null
+			};
+		}
+	}
+
+	// Distance radio → pendingFilters
+	$: {
+		const km = distanceRadioValue === 'any' ? null : Number(distanceRadioValue);
+		const validKm = km !== null && !Number.isNaN(km) ? km : null;
+		if (validKm !== pendingDistancePreset) {
+			pendingDistancePreset = validKm;
+			pendingFilters = { ...pendingFilters, distanceMaxKm: validKm };
+		}
+	}
+	function countActive(filters: MixedFilterState): number {
+		let n = 0;
+		if (filters.languages.length > 0) n++;
+		if (filters.categories.length > 0) n++;
+		if (filters.discountMin != null) n++;
+		if (filters.durationMin != null || filters.durationMax != null) n++;
+		if (filters.distanceMaxKm != null) n++;
+		return n;
+	}
+
+	// ---------------------------------------------------------------------------
+	// Reactive pipeline: filter → sort → source caps → global cap
+	// ---------------------------------------------------------------------------
+	$: activeFilterCount = countActive(activeFilters);
+	$: totalActiveCount = activeFilterCount + (activeSort !== 'relevance' ? 1 : 0);
+	$: filteredItems = applyFilters(normalizedPool, activeFilters);
+	$: sortedItems = sortItems(filteredItems, activeSort, activeSortDir);
+
+	$: sourceCaps = (() => {
+		const caps: Record<string, number | null> = {};
+		for (const source of moduleSources) {
+			const cap = source.max_items;
+			if (source.entity_type) {
+				if (source.entity_type === 'stopover_tours' || source.entity_type === 'stopover_tour') {
+					caps['stopover_tour'] = cap ?? null;
+				} else if (
+					source.entity_type === 'stopover_place_to_visit' ||
+					source.entity_type === 'stopover_places_to_visit' ||
+					source.entity_type === 'stopover_activity' ||
+					source.entity_type === 'stopover_activities'
+				) {
+					caps['stopover_place_to_visit'] = cap ?? null;
+				} else {
+					caps[source.entity_type] = cap ?? null;
+				}
+			}
+		}
+		return caps;
+	})();
+	$: cappedBySource = applySourceCaps(sortedItems, sourceCaps);
+	$: globalCap =
+		typeof moduleConfig?.max_items === 'number' && moduleConfig.max_items > 0
+			? moduleConfig.max_items
+			: cappedBySource.length;
+	$: displayedItems = cappedBySource.slice(0, globalCap);
+
+	// ---------------------------------------------------------------------------
+	// CTA / site settings
+	// ---------------------------------------------------------------------------
 	const cta =
 		$page.data.siteSettings.translations?.[0]?.labels?.filter((v) => v.name === 'view-more')?.[0] ||
 		'Add view more label';
 	const ctaText = typeof cta === 'string' ? cta : cta.value;
-	const locale = $page.data.locale || 'en';
 
 	const modulePrimaryCtaLabel = moduleTranslation?.primary_cta_label || '';
 	const modulePrimaryCtaUrl = moduleTranslation?.primary_cta_url || '';
@@ -81,32 +485,194 @@
 		const path = map(replace(/\/\//g, '/'), getPathRecursive(schema));
 		return (path as unknown as Record<string, string>)[$page.data.locale] || '';
 	}
-
-	function getEntityTypeLabel(collection: string | null | undefined): string {
-		const normalized = (collection || '').toLowerCase();
-
-		const labels = {
-			en: { tour: 'Tour', activity: 'Activity' },
-			es: { tour: 'Tour', activity: 'Actividad' },
-			pt: { tour: 'Tour', activity: 'Atividade' }
-		};
-
-		const localizedLabels = labels[locale as keyof typeof labels] || labels.en;
-
-		if (normalized.includes('tour')) return localizedLabels.tour;
-		if (
-			normalized.includes('place_to_visit') ||
-			normalized.includes('activity') ||
-			normalized.includes('activities')
-		)
-			return localizedLabels.activity;
-
-		return '';
-	}
 </script>
 
-<div data-items-count={item?.items?.length ?? moduleItems.length}>
-	{#if isNil(moduleItems) || moduleItems.length === 0}
+<div data-items-count={displayedItems.length}>
+	{#if hasAnyFilter && normalizedPool.length > 0}
+		<div class="mb-4 mt-4 flex justify-end py-1">
+			<div class="flex items-center gap-2">
+				<button
+					type="button"
+					class={buttonVariants({ variant: 'outline-primary-main', size: 'slim' })}
+					onclick={() => (modalOpen = true)}
+				>
+					<Regular.Filter class="size-4 shrink-0" />
+					{filterLabels.filters}
+					{#if totalActiveCount > 0}
+						<span
+							class="inline-flex size-5 items-center justify-center rounded-full bg-primary text-d3 text-common-white"
+						>
+							{totalActiveCount}
+						</span>
+					{/if}
+				</button>
+				<span class="text-d1 text-grey-600">
+					{displayedItems.length} / {normalizedPool.length}
+				</span>
+			</div>
+		</div>
+
+		<Modal
+			bind:open={modalOpen}
+			title={filterLabels.filters}
+			titleSize="16px"
+			size="narrow"
+			mainActionLabel={filterLabels.apply}
+			secondaryActionLabel={filterLabels.reset}
+			onMainAction={applyAll}
+			onSecondaryAction={resetAll}
+		>
+			<div class="flex flex-col gap-6">
+				<!-- Sort section -->
+				<div>
+					<p class="mb-2 text-d1 font-medium text-grey-700">{filterLabels.sort}</p>
+					<div class="flex items-stretch gap-2">
+					<div class="flex-1">
+						<Select
+							label=""
+							bind:value={pendingSort}
+							options={sortSelectOptions}
+							onValueChange={(val) => {
+								pendingSort = val as SortOption;
+							}}
+						/>
+					</div>
+					{#if pendingSort !== 'relevance'}
+						<button
+							type="button"
+							class="my-2 flex w-10 items-center justify-center rounded border border-grey-300 text-grey-700 hover:border-primary"
+							title="{filterLabels.sortDir}: {pendingSortDir === 'asc'
+								? filterLabels.sortAsc
+								: filterLabels.sortDesc}"
+							aria-label={filterLabels.sortDir}
+							onclick={() => {
+								pendingSortDir = pendingSortDir === 'asc' ? 'desc' : 'asc';
+							}}
+						>
+							<span
+								class="transition-transform duration-200"
+								style={pendingSortDir === 'asc' ? 'transform: scaleY(-1)' : ''}
+							>
+								<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" class="fill-current">
+									<path d="M4 18q-.425 0-.712-.288T3 17t.288-.712T4 16h4q.425 0 .713.288T9 17t-.288.713T8 18zm0-5q-.425 0-.712-.288T3 12t.288-.712T4 11h10q.425 0 .713.288T15 12t-.288.713T14 13zm0-5q-.425 0-.712-.288T3 7t.288-.712T4 6h16q.425 0 .713.288T21 7t-.288.713T20 8z"/>
+								</svg>
+							</span>
+						</button>
+					{/if}
+				</div>
+				</div>
+
+				<!-- Language (multi-select → checkboxes, horizontal wrap) -->
+				{#if filterToggles.language && availableLanguages.length > 0}
+					<fieldset class="flex flex-col gap-2">
+						<legend class="mb-1 text-d1 font-medium text-grey-700">
+							{filterLabels.language}
+						</legend>
+						<div class="flex flex-wrap gap-x-4 gap-y-2">
+							{#each availableLanguages as lang (lang.code)}
+								<label class="flex cursor-pointer items-center gap-2 text-b text-grey-700">
+									<Checkbox
+										checked={pendingFilters.languages.includes(lang.code)}
+										onCheckedChange={() => toggleLanguage(lang.code)}
+									/>
+									<span>{lang.label}</span>
+								</label>
+							{/each}
+						</div>
+					</fieldset>
+				{/if}
+
+				<!-- Category (multi-select → checkboxes, horizontal wrap) -->
+				{#if filterToggles.category && availableCategories.length > 0}
+					<fieldset class="flex flex-col gap-2">
+						<legend class="mb-1 text-d1 font-medium text-grey-700">
+							{filterLabels.category}
+						</legend>
+						<div class="flex flex-wrap gap-x-4 gap-y-2">
+							{#each availableCategories as cat (cat.id)}
+								<label class="flex cursor-pointer items-center gap-2 text-b text-grey-700">
+									<Checkbox
+										checked={pendingFilters.categories.includes(cat.id)}
+										onCheckedChange={() => toggleCategory(cat.id)}
+									/>
+									<span>{cat.label}</span>
+								</label>
+							{/each}
+						</div>
+					</fieldset>
+				{/if}
+
+				<!-- Discount (slider, step 5) -->
+				{#if filterToggles.discount}
+					<fieldset class="flex flex-col gap-2">
+						<legend class="text-d1 font-medium text-grey-700">
+							{filterLabels.discount}
+							<span class="ml-1 font-normal text-grey-500">
+								{discountSliderValue > 0
+									? `\u2265 ${discountSliderValue}%`
+									: `(${filterLabels.anyDuration})`}
+							</span>
+						</legend>
+						<div class="pb-6 pt-4">
+							<Slider
+								bind:value={discountSliderValue}
+								min={0}
+								max={100}
+								step={5}
+								showTooltip={true}
+								formatTooltip={(v) => (v === 0 ? '\u2014' : `\u2265 ${v}%`)}
+							/>
+						</div>
+						<div class="flex justify-between text-d3 text-grey-500">
+							<span>0%</span>
+							<span>100%</span>
+						</div>
+					</fieldset>
+				{/if}
+
+				<!-- Duration (single-select → radio, horizontal wrap) -->
+				{#if filterToggles.duration}
+					<fieldset class="flex flex-col gap-2">
+						<legend class="mb-1 text-d1 font-medium text-grey-700">
+							{filterLabels.duration}
+						</legend>
+						<RadioGroup
+							bind:value={durationRadioValue}
+							class="flex-row flex-wrap gap-x-4 gap-y-2"
+						>
+							<RadioItem value="any" label={filterLabels.anyDuration} />
+							{#each durationPresets as preset (preset.label)}
+								<RadioItem value={preset.label} label={preset.label} />
+							{/each}
+						</RadioGroup>
+					</fieldset>
+				{/if}
+
+				<!-- Distance (single-select → radio, horizontal wrap) -->
+				{#if filterToggles.distance}
+					<fieldset class="flex flex-col gap-2">
+						<legend class="mb-1 text-d1 font-medium text-grey-700">
+							{filterLabels.distance}
+						</legend>
+						<RadioGroup
+							bind:value={distanceRadioValue}
+							class="flex-row flex-wrap gap-x-4 gap-y-2"
+						>
+							<RadioItem value="any" label={filterLabels.anyDistance} />
+							{#each distancePresets as km (km)}
+								<RadioItem value={String(km)} label={`\u2264 ${km} km`} />
+							{/each}
+						</RadioGroup>
+						{#if filterLabels.referencePoint}
+							<p class="text-d3 text-grey-600">{filterLabels.referencePoint}</p>
+						{/if}
+					</fieldset>
+				{/if}
+			</div>
+		</Modal>
+	{/if}
+
+	{#if normalizedPool.length === 0}
 		<div
 			class="my-6 grid grid-cols-[repeat(auto-fit,minmax(140px,1fr))] items-stretch gap-2 md:grid-cols-[repeat(auto-fit,minmax(320px,1fr))] md:gap-4"
 		>
@@ -125,8 +691,9 @@
 		<ul
 			class="my-6 grid grid-cols-[repeat(auto-fit,minmax(140px,1fr))] items-stretch gap-2 md:grid-cols-[repeat(auto-fill,minmax(320px,1fr))] md:gap-4"
 		>
-			{#each moduleItems as promo}
-				{@const entityTypeLabel = getEntityTypeLabel(promo._collection)}
+			{#each displayedItems as normalized (normalized.stableKey)}
+				{@const promo = normalized.raw}
+				{@const entityTypeLabel = getEntityTypeLabel(normalized.collection)}
 				{#if promo.parent_page && promo.translations?.[0]?.path && promo.main_image}
 					<li class="max-w-[398px]">
 						<PromoShow
@@ -141,7 +708,9 @@
 								/>
 							</Children.Image>
 							{#if promo.promo_discount_percent || promo.promo_discount_amount}
-								<div class="col-start-2 row-start-2 mb-2 inline-flex items-end justify-self-end gap-1 md:gap-2">
+								<div
+									class="col-start-2 row-start-2 mb-2 inline-flex items-end justify-self-end gap-1 md:gap-2"
+								>
 									{#if entityTypeLabel}
 										<Children.Discount class="mb-0 bg-secondary text-grey-50">
 											{entityTypeLabel}

--- a/src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte
+++ b/src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte
@@ -14,6 +14,7 @@
 	import { getPathRecursive } from '$lib/i18n/cannonicals';
 	import { isNotNil, map, replace } from 'ramda';
 	import { getDirectusImage } from '../../stopover/utils';
+	import { cn } from '$lib/utils';
 	import {
 		applyFilters,
 		applySourceCaps,
@@ -216,10 +217,10 @@
 		distance: moduleConfig?.filter_distance_enabled ?? true
 	};
 
-	// Only render filter UI if at least one filter is enabled AND has facets worth showing.
+	// Category is shown as immediate-apply chips above the grid (not inside the modal).
+	// The modal only handles language, discount, duration, and distance.
 	const hasAnyFilter =
 		(filterToggles.language && availableLanguages.length > 0) ||
-		(filterToggles.category && availableCategories.length > 0) ||
 		filterToggles.discount ||
 		filterToggles.duration ||
 		filterToggles.distance;
@@ -388,6 +389,15 @@
 		};
 	}
 
+	// Category chips apply immediately (bypass modal pending/apply flow)
+	function toggleCategoryImmediate(id: number) {
+		const next = activeFilters.categories.includes(id)
+			? activeFilters.categories.filter((c) => c !== id)
+			: [...activeFilters.categories, id];
+		activeFilters = { ...activeFilters, categories: next };
+		pendingFilters = { ...pendingFilters, categories: next };
+	}
+
 	// Discount slider → pendingFilters (0 = no filter)
 	$: {
 		const next = discountSliderValue > 0 ? discountSliderValue : null;
@@ -425,7 +435,7 @@
 	function countActive(filters: MixedFilterState): number {
 		let n = 0;
 		if (filters.languages.length > 0) n++;
-		if (filters.categories.length > 0) n++;
+		// categories are counted separately (shown as chips outside the modal)
 		if (filters.discountMin != null) n++;
 		if (filters.durationMin != null || filters.durationMax != null) n++;
 		if (filters.distanceMaxKm != null) n++;
@@ -488,8 +498,30 @@
 </script>
 
 <div data-items-count={displayedItems.length}>
+	<!-- Category chips: always-visible multi-select above the grid -->
+	{#if filterToggles.category && availableCategories.length > 0 && normalizedPool.length > 0}
+		<nav aria-label={filterLabels.category} class="mb-4 mt-4 flex flex-wrap gap-2">
+			{#each availableCategories as cat (cat.id)}
+				{@const isSelected = activeFilters.categories.includes(cat.id)}
+				<button
+					type="button"
+					aria-pressed={isSelected}
+					onclick={() => toggleCategoryImmediate(cat.id)}
+					class={cn(
+						'rounded-full border px-4 py-1 text-d1 transition-colors',
+						isSelected
+							? 'border-primary bg-primary text-common-white'
+							: 'border-grey-300 bg-common-white text-grey-700 hover:border-primary hover:text-primary'
+					)}
+				>
+					{cat.label}
+				</button>
+			{/each}
+		</nav>
+	{/if}
+
 	{#if hasAnyFilter && normalizedPool.length > 0}
-		<div class="mb-4 mt-4 flex justify-end py-1">
+		<div class="mb-4 mt-2 flex justify-end py-1">
 			<div class="flex items-center gap-2">
 				<button
 					type="button"
@@ -582,27 +614,7 @@
 					</fieldset>
 				{/if}
 
-				<!-- Category (multi-select → checkboxes, horizontal wrap) -->
-				{#if filterToggles.category && availableCategories.length > 0}
-					<fieldset class="flex flex-col gap-2">
-						<legend class="mb-1 text-d1 font-medium text-grey-700">
-							{filterLabels.category}
-						</legend>
-						<div class="flex flex-wrap gap-x-4 gap-y-2">
-							{#each availableCategories as cat (cat.id)}
-								<label class="flex cursor-pointer items-center gap-2 text-b text-grey-700">
-									<Checkbox
-										checked={pendingFilters.categories.includes(cat.id)}
-										onCheckedChange={() => toggleCategory(cat.id)}
-									/>
-									<span>{cat.label}</span>
-								</label>
-							{/each}
-						</div>
-					</fieldset>
-				{/if}
-
-				<!-- Discount (slider, step 5) -->
+			<!-- Discount (slider, step 5) -->
 				{#if filterToggles.discount}
 					<fieldset class="flex flex-col gap-2">
 						<legend class="text-d1 font-medium text-grey-700">

--- a/src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte
+++ b/src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte
@@ -216,12 +216,10 @@
 		distance: moduleConfig?.filter_distance_enabled ?? true
 	};
 
-	// Only render filter UI if at least one filter is enabled.
-	// Category shows even with 0 items (displays an empty-state message) so it's
-	// always reachable for debugging while Directus data is being populated.
+	// Only render filter UI if at least one filter is enabled AND has facets worth showing.
 	const hasAnyFilter =
 		(filterToggles.language && availableLanguages.length > 0) ||
-		filterToggles.category ||
+		(filterToggles.category && availableCategories.length > 0) ||
 		filterToggles.discount ||
 		filterToggles.duration ||
 		filterToggles.distance;
@@ -525,46 +523,6 @@
 			onSecondaryAction={resetAll}
 		>
 			<div class="flex flex-col gap-6">
-				<!-- Category (multi-select listbox – first for visibility) -->
-				{#if filterToggles.category}
-					<fieldset class="flex flex-col gap-2">
-						<legend class="mb-1 text-d1 font-medium text-grey-700">
-							{filterLabels.category}
-						</legend>
-						{#if availableCategories.length > 0}
-							<div
-								role="listbox"
-								aria-multiselectable="true"
-								aria-label={filterLabels.category}
-								class="max-h-44 overflow-y-auto rounded-lg border border-grey-300 bg-common-white"
-							>
-								{#each availableCategories as cat (cat.id)}
-									{@const isChecked = pendingFilters.categories.includes(cat.id)}
-									<label
-										class="flex cursor-pointer select-none items-center gap-3 px-3 py-2.5 transition-colors hover:bg-background-lightblue {isChecked ? 'bg-background-lightblue' : ''}"
-									>
-										<Checkbox
-											checked={isChecked}
-											onCheckedChange={() => toggleCategory(cat.id)}
-										/>
-										<span class="text-b text-grey-700">{cat.label}</span>
-									</label>
-								{/each}
-							</div>
-							{#if pendingFilters.categories.length > 0}
-								<p class="text-d3 text-grey-500">
-									{pendingFilters.categories.length}
-									{pendingFilters.categories.length === 1 ? 'seleccionada' : 'seleccionadas'}
-								</p>
-							{/if}
-						{:else}
-							<p class="text-d3 text-grey-400 italic">
-								Sin categorías disponibles — asigna <code>experience_category</code> en Directus.
-							</p>
-						{/if}
-					</fieldset>
-				{/if}
-
 				<!-- Sort section -->
 				<div>
 					<p class="mb-2 text-d1 font-medium text-grey-700">{filterLabels.sort}</p>
@@ -604,7 +562,27 @@
 				</div>
 				</div>
 
-				<!-- Language (multi-select → checkboxes, horizontal wrap) -->
+				<!-- Category (multi-select → checkboxes, horizontal wrap) -->
+			{#if filterToggles.category && availableCategories.length > 0}
+				<fieldset class="flex flex-col gap-2">
+					<legend class="mb-1 text-d1 font-medium text-grey-700">
+						{filterLabels.category}
+					</legend>
+					<div class="flex flex-wrap gap-x-4 gap-y-2">
+						{#each availableCategories as cat (cat.id)}
+							<label class="flex cursor-pointer items-center gap-2 text-b text-grey-700">
+								<Checkbox
+									checked={pendingFilters.categories.includes(cat.id)}
+									onCheckedChange={() => toggleCategory(cat.id)}
+								/>
+								<span>{cat.label}</span>
+							</label>
+						{/each}
+					</div>
+				</fieldset>
+			{/if}
+
+			<!-- Language (multi-select → checkboxes, horizontal wrap) -->
 				{#if filterToggles.language && availableLanguages.length > 0}
 					<fieldset class="flex flex-col gap-2">
 						<legend class="mb-1 text-d1 font-medium text-grey-700">

--- a/src/lib/components/directus/general-components/mixed-experience-module/utils.ts
+++ b/src/lib/components/directus/general-components/mixed-experience-module/utils.ts
@@ -1,0 +1,390 @@
+import type { PathSchema } from '$lib/domain/pages';
+
+// Reference point for the distance filter: "Iglesia del Carmen, Vía España" (Panama City).
+export const IGLESIA_DEL_CARMEN: GeoPoint = { lat: 8.9936, lng: -79.5197 };
+
+export type GeoPoint = { lat: number; lng: number };
+
+export type RawCategoryTranslation = {
+	languages_code?: string | null;
+	label?: string | null;
+};
+
+export type RawCategory = {
+	id?: number | null;
+	translations?: RawCategoryTranslation[] | null;
+};
+
+export type RawMixedItem = {
+	id?: number | string | null;
+	_collection?: string | null;
+	priority?: number | null;
+	date_created?: string | null;
+	main_image?: string | null;
+	promo_discount_percent?: number | null;
+	promo_discount_amount?: number | null;
+	duration?: number | string | null;
+	experience_category?: number | RawCategory | null;
+	supported_languages?: unknown;
+	meeting_point?: unknown;
+	location?: unknown;
+	parent_page?: PathSchema | null;
+	translations?: Array<{
+		name?: string | null;
+		path?: string | null;
+		promo_name?: string | null;
+	}>;
+};
+
+export type NormalizedMixedItem = {
+	stableKey: string;
+	collection: string;
+	id: number | string | null;
+	name: string;
+	priority: number;
+	dateCreated: string | null;
+	recency: number;
+	promoDiscountPercent: number | null;
+	promoDiscountAmount: number | null;
+	duration: number | null;
+	experienceCategory: number | null;
+	categoryLabel: string | null;
+	supportedLanguages: string[];
+	geoPoint: GeoPoint | null;
+	distanceFromCenterKm: number | null;
+	raw: RawMixedItem;
+};
+
+export type TranslationLike = { languages_code?: string | null };
+
+/**
+ * Picks the translation row matching `lang`, falling back to `fallback`
+ * and finally the first available row.
+ */
+export function pickTranslation<T extends TranslationLike>(
+	translations: T[] | null | undefined,
+	lang: string | null | undefined,
+	fallback = 'en'
+): T | undefined {
+	if (!translations || translations.length === 0) return undefined;
+	return (
+		(lang ? translations.find((t) => t.languages_code === lang) : undefined) ??
+		translations.find((t) => t.languages_code === fallback) ??
+		translations[0]
+	);
+}
+
+/**
+ * Parses a Directus GeoJSON point into `{ lat, lng }`.
+ * Accepts the shape `{ type: 'Point', coordinates: [lng, lat] }` (GeoJSON canonical)
+ * as well as already-parsed `{ lat, lng }` objects and JSON-string-encoded forms.
+ */
+export function parseGeoPoint(value: unknown): GeoPoint | null {
+	if (value == null) return null;
+
+	if (typeof value === 'string') {
+		try {
+			return parseGeoPoint(JSON.parse(value));
+		} catch {
+			return null;
+		}
+	}
+
+	if (typeof value !== 'object') return null;
+
+	const record = value as Record<string, unknown>;
+
+	if (typeof record.lat === 'number' && typeof record.lng === 'number') {
+		return { lat: record.lat, lng: record.lng };
+	}
+
+	const coords = record.coordinates;
+	if (Array.isArray(coords) && coords.length >= 2) {
+		const lng = Number(coords[0]);
+		const lat = Number(coords[1]);
+		if (Number.isFinite(lat) && Number.isFinite(lng)) return { lat, lng };
+	}
+
+	return null;
+}
+
+/**
+ * Normalizes `duration` to a number. `stopover_tour.duration` is stored as a number,
+ * `stopover_place_to_visit.duration` as a string (sometimes with units). Returns `null`
+ * if the value cannot be parsed to a finite number.
+ */
+export function parseDuration(value: unknown): number | null {
+	if (value == null) return null;
+	if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+	if (typeof value === 'string') {
+		const trimmed = value.trim();
+		if (!trimmed) return null;
+		const match = trimmed.match(/-?\d+(\.\d+)?/);
+		if (!match) return null;
+		const parsed = Number(match[0]);
+		return Number.isFinite(parsed) ? parsed : null;
+	}
+	return null;
+}
+
+/**
+ * `supported_languages` is stored as jsonb, typically as `Record<string, boolean>`
+ * (truthy keys are enabled languages) or as an array of language codes.
+ * Returns the enabled language codes as lowercase strings.
+ */
+export function parseSupportedLanguages(value: unknown): string[] {
+	if (value == null) return [];
+	if (Array.isArray(value)) {
+		return value.filter((v): v is string => typeof v === 'string').map((v) => v.toLowerCase());
+	}
+	if (typeof value === 'object') {
+		return Object.entries(value as Record<string, unknown>)
+			.filter(([, v]) => Boolean(v))
+			.map(([k]) => k.toLowerCase());
+	}
+	if (typeof value === 'string') {
+		try {
+			return parseSupportedLanguages(JSON.parse(value));
+		} catch {
+			return value
+				.split(/[,;\s]+/)
+				.map((v) => v.trim().toLowerCase())
+				.filter(Boolean);
+		}
+	}
+	return [];
+}
+
+export function stableKey(collection: string | null | undefined, id: number | string | null | undefined): string {
+	return `${collection ?? 'unknown'}:${id ?? ''}`;
+}
+
+const toTimestamp = (value: string | null | undefined): number => {
+	if (!value) return 0;
+	const parsed = Date.parse(value);
+	return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+/**
+ * Great-circle distance in kilometers between two points using the haversine formula.
+ */
+export function haversineKm(a: GeoPoint, b: GeoPoint): number {
+	const R = 6371;
+	const dLat = ((b.lat - a.lat) * Math.PI) / 180;
+	const dLng = ((b.lng - a.lng) * Math.PI) / 180;
+	const sinLat = Math.sin(dLat / 2);
+	const sinLng = Math.sin(dLng / 2);
+	const x =
+		sinLat * sinLat +
+		Math.cos((a.lat * Math.PI) / 180) * Math.cos((b.lat * Math.PI) / 180) * sinLng * sinLng;
+	return R * 2 * Math.atan2(Math.sqrt(x), Math.sqrt(1 - x));
+}
+
+/**
+ * Extracts the category id and localized label from `raw.experience_category`.
+ * When the server has deep-fetched the relation it comes as an object with
+ * `id` + `translations` (already filtered by locale server-side). When only
+ * the FK was selected, it comes as a plain number.
+ */
+function extractCategory(raw: unknown): { id: number | null; label: string | null } {
+	if (raw == null) return { id: null, label: null };
+	if (typeof raw === 'number') return { id: raw, label: null };
+	if (typeof raw === 'object') {
+		const record = raw as RawCategory;
+		const id = typeof record.id === 'number' ? record.id : null;
+		const translations = Array.isArray(record.translations) ? record.translations : [];
+		const label = translations[0]?.label ?? null;
+		return { id, label };
+	}
+	return { id: null, label: null };
+}
+
+export function normalizeMixedItem(raw: RawMixedItem): NormalizedMixedItem {
+	const collection = raw._collection ?? 'unknown';
+	const geoSource = collection === 'stopover_tour' ? raw.meeting_point : raw.location;
+	const geoPoint = parseGeoPoint(geoSource);
+	const { id: experienceCategory, label: categoryLabel } = extractCategory(raw.experience_category);
+
+	return {
+		stableKey: stableKey(collection, raw.id ?? null),
+		collection,
+		id: (raw.id as number | string | null | undefined) ?? null,
+		name: raw.translations?.[0]?.name ?? '',
+		priority: raw.priority ?? 0,
+		dateCreated: raw.date_created ?? null,
+		recency: toTimestamp(raw.date_created),
+		promoDiscountPercent: raw.promo_discount_percent ?? null,
+		promoDiscountAmount: raw.promo_discount_amount ?? null,
+		duration: parseDuration(raw.duration),
+		experienceCategory,
+		categoryLabel,
+		supportedLanguages: parseSupportedLanguages(raw.supported_languages),
+		geoPoint,
+		distanceFromCenterKm: geoPoint ? haversineKm(IGLESIA_DEL_CARMEN, geoPoint) : null,
+		raw
+	};
+}
+
+/**
+ * Returns a locale-aware language display name for a 2-letter code (e.g. `en` →
+ * `English` when `locale=en`, `Inglés` when `locale=es`). Falls back to the
+ * uppercased code when `Intl.DisplayNames` is unavailable or the code cannot be
+ * resolved.
+ */
+export function getLanguageDisplayName(code: string, locale: string | null | undefined): string {
+	const normalized = code.trim().toLowerCase();
+	if (!normalized) return '';
+	try {
+		if (typeof Intl !== 'undefined' && typeof Intl.DisplayNames === 'function') {
+			const display = new Intl.DisplayNames([locale || 'en'], { type: 'language' });
+			const resolved = display.of(normalized);
+			if (resolved && resolved.toLowerCase() !== normalized) return resolved;
+		}
+	} catch {
+		// ignore - fall through to the uppercase fallback
+	}
+	return normalized.toUpperCase();
+}
+
+// -----------------------------------------------------------------------------
+// Filters
+// -----------------------------------------------------------------------------
+
+export type MixedFilterState = {
+	languages: string[]; // OR — empty array means "no filter"
+	categories: number[]; // OR — empty array means "no filter"
+	discountMin: number | null; // minimum discount percent; null = no filter
+	durationMin: number | null;
+	durationMax: number | null;
+	distanceMaxKm: number | null;
+};
+
+export const emptyFilterState = (): MixedFilterState => ({
+	languages: [],
+	categories: [],
+	discountMin: null,
+	durationMin: null,
+	durationMax: null,
+	distanceMaxKm: null
+});
+
+export function applyFilters(
+	items: NormalizedMixedItem[],
+	filters: MixedFilterState
+): NormalizedMixedItem[] {
+	return items.filter((item) => {
+		if (filters.languages.length > 0) {
+			if (!filters.languages.some((lang) => item.supportedLanguages.includes(lang))) return false;
+		}
+		if (filters.categories.length > 0) {
+			if (item.experienceCategory == null || !filters.categories.includes(item.experienceCategory))
+				return false;
+		}
+		if (filters.discountMin != null) {
+			if (item.promoDiscountPercent == null || item.promoDiscountPercent < filters.discountMin)
+				return false;
+		}
+		if (filters.durationMin != null) {
+			if (item.duration == null || item.duration < filters.durationMin) return false;
+		}
+		if (filters.durationMax != null) {
+			if (item.duration == null || item.duration > filters.durationMax) return false;
+		}
+		if (filters.distanceMaxKm != null) {
+			if (item.distanceFromCenterKm == null || item.distanceFromCenterKm > filters.distanceMaxKm)
+				return false;
+		}
+		return true;
+	});
+}
+
+// -----------------------------------------------------------------------------
+// Sorting
+// -----------------------------------------------------------------------------
+
+export type SortOption = 'relevance' | 'discount_percent' | 'distance_from_center' | 'duration' | 'name';
+export type SortDir = 'asc' | 'desc';
+
+export function sortItems(
+	items: NormalizedMixedItem[],
+	sort: SortOption,
+	dir: SortDir
+): NormalizedMixedItem[] {
+	const d = dir === 'asc' ? 1 : -1;
+	const copy = [...items];
+
+	switch (sort) {
+		case 'relevance':
+			return copy.sort((a, b) => {
+				if (b.priority !== a.priority) return b.priority - a.priority;
+				const ap = a.promoDiscountPercent ?? -1;
+				const bp = b.promoDiscountPercent ?? -1;
+				if (bp !== ap) return bp - ap;
+				if (b.recency !== a.recency) return b.recency - a.recency;
+				return a.stableKey.localeCompare(b.stableKey);
+			});
+
+		case 'discount_percent':
+			return copy.sort((a, b) => {
+				const aVal = a.promoDiscountPercent ?? (dir === 'asc' ? Infinity : -Infinity);
+				const bVal = b.promoDiscountPercent ?? (dir === 'asc' ? Infinity : -Infinity);
+				if (aVal !== bVal) return d * (bVal - aVal);
+				return a.stableKey.localeCompare(b.stableKey);
+			});
+
+		case 'distance_from_center':
+			return copy.sort((a, b) => {
+				const aVal = a.distanceFromCenterKm ?? Infinity;
+				const bVal = b.distanceFromCenterKm ?? Infinity;
+				if (aVal !== bVal) return d * (aVal - bVal);
+				return a.stableKey.localeCompare(b.stableKey);
+			});
+
+		case 'duration':
+			return copy.sort((a, b) => {
+				const aVal = a.duration ?? (dir === 'asc' ? Infinity : -Infinity);
+				const bVal = b.duration ?? (dir === 'asc' ? Infinity : -Infinity);
+				if (aVal !== bVal) return d * (aVal - bVal);
+				return a.stableKey.localeCompare(b.stableKey);
+			});
+
+		case 'name':
+			return copy.sort((a, b) => {
+				const cmp = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+				if (cmp !== 0) return d * cmp;
+				return a.stableKey.localeCompare(b.stableKey);
+			});
+	}
+}
+
+// -----------------------------------------------------------------------------
+// max_items caps — source first, then global
+// -----------------------------------------------------------------------------
+
+/**
+ * Applies `source.max_items` caps per collection. Items without a matching cap
+ * (or with a cap of `-1` / `null`) are passed through unchanged.
+ * Must be applied AFTER sorting so the highest-ranked items per source survive.
+ */
+export function applySourceCaps<T extends { collection: string }>(
+	items: T[],
+	caps: Record<string, number | null | undefined>
+): T[] {
+	const counts: Record<string, number> = {};
+	const out: T[] = [];
+
+	for (const item of items) {
+		const cap = caps[item.collection];
+		if (cap == null || cap < 0) {
+			out.push(item);
+			continue;
+		}
+		const c = counts[item.collection] ?? 0;
+		if (c < cap) {
+			out.push(item);
+			counts[item.collection] = c + 1;
+		}
+	}
+
+	return out;
+}

--- a/src/lib/components/directus/section/tabs/tabs.svelte
+++ b/src/lib/components/directus/section/tabs/tabs.svelte
@@ -10,6 +10,8 @@
 	import { buttonVariants } from '$ui/components/button';
 	import { crossfade } from 'svelte/transition';
 	import { cubicInOut } from 'svelte/easing';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
 
 	export let section: SectionSchema;
 
@@ -39,7 +41,35 @@
 
 	let tabNames = setTabContext();
 
-	let value = [section_id, id, 0].join('-');
+	// Each tabs section uses its own query param key so multiple tab blocks
+	// on the same page don't collide: ?tab_<section_id>=<index>
+	const paramKey = `tab_${section_id ?? id}`;
+
+	function makeTabValue(index: number) {
+		return [section_id, id, index].join('-');
+	}
+
+	function getInitialValue(): string {
+		const raw = $page.url.searchParams.get(paramKey);
+		const idx = raw !== null ? parseInt(raw, 10) : NaN;
+		const tabCount = section_content?.length ?? 0;
+		if (!Number.isNaN(idx) && idx >= 0 && idx < tabCount) {
+			return makeTabValue(idx);
+		}
+		return makeTabValue(0);
+	}
+
+	let value = getInitialValue();
+
+	function onTabChange(newValue: string) {
+		value = newValue;
+		// Derive the index back from the composite value so we store a simple number.
+		const parts = newValue.split('-');
+		const idx = parseInt(parts[parts.length - 1], 10);
+		const url = new URL($page.url);
+		url.searchParams.set(paramKey, String(idx));
+		goto(url.toString(), { replaceState: true, keepFocus: true, noScroll: true });
+	}
 
 	const [send, receive] = crossfade({
 		duration: 250,
@@ -59,7 +89,7 @@
 			class={cn(sectionVariants(variantObject), 'relative')}
 			class:col-start-2={horizontal_behaviour === 'container-grid'}
 		>
-			<Tabs.Root class="col-span-full mb-normal" bind:value>
+			<Tabs.Root class="col-span-full mb-normal" bind:value onValueChange={onTabChange}>
 				<Tabs.List class="flex flex-wrap content-start justify-around gap-2">
 					{#each $tabNames as tabName, i}
 						<Tabs.Trigger

--- a/src/lib/components/directus/section/tabs/tabs.svelte
+++ b/src/lib/components/directus/section/tabs/tabs.svelte
@@ -12,6 +12,7 @@
 	import { cubicInOut } from 'svelte/easing';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
+	import { browser } from '$app/environment';
 
 	export let section: SectionSchema;
 
@@ -50,6 +51,7 @@
 	}
 
 	function getInitialValue(): string {
+		if (!browser) return makeTabValue(0);
 		const raw = $page.url.searchParams.get(paramKey);
 		const idx = raw !== null ? parseInt(raw, 10) : NaN;
 		const tabCount = section_content?.length ?? 0;

--- a/src/lib/components/directus/stopover/package-page.svelte
+++ b/src/lib/components/directus/stopover/package-page.svelte
@@ -9,7 +9,13 @@
 	import { BaseTextContent } from '$lib/components/site/text-content/base';
 	import { BannerAlert } from '$lib/components/site/text-content/banner-alert';
 	import { isStopoverTourTranslations } from '$lib/directus/tours/utlis';
-	import { InformativeBoxContainer } from '$ui/components/boxes/informative';
+	import {
+		InformativeBoxContainer,
+		InformativeBox,
+		InformativeBoxIcon,
+		InformativeBoxTitle,
+		InformativeBoxDescription
+	} from '$ui/components/boxes/informative';
 	import { AnunciosImportantes, CheckIn } from '$ui/components/pictograms';
 	import { Body, Heading } from '$ui/components/typography';
 	import { ContactCard } from '$lib/components/site/items/cards/contact';
@@ -123,40 +129,34 @@
 	</div>
 	<SpokenLanguages item={stopover_package} />
 	<div>
-		<InformativeBoxContainer let:Box>
-			<Box
-				alignment="center"
-				class="max-h-full border-primary bg-primary"
-				let:Icon
-				let:Title
-				let:Description
-			>
-				<Icon>
-					<CheckIn style="transparent" />
-				</Icon>
-				<Title theme="invert">
-					{labels?.get('included')}
-				</Title>
-				<Description tag="ul" theme="invert">
-					<ul>
-						{#each included?.map((i) => i.name) || [] as item}
-							<li>{item}</li>
-						{/each}
-					</ul>
-				</Description>
-			</Box>
-			<Box alignment="center" class="max-h-full bg-grey-700" let:Icon let:Title let:Description>
-				<Icon>
-					<AnunciosImportantes style="monochrome" />
-				</Icon>
-				<Title theme="invert">{labels?.get('not-included')}</Title>
-				<Description tag="ul" theme="invert">
-					{#each not_included?.map((i) => i.name) || [] as item}
+	<InformativeBoxContainer>
+		<InformativeBox alignment="center" class="max-h-full border-primary bg-primary">
+			<InformativeBoxIcon>
+				<CheckIn style="transparent" />
+			</InformativeBoxIcon>
+			<InformativeBoxTitle theme="invert">
+				{labels?.get('included')}
+			</InformativeBoxTitle>
+			<InformativeBoxDescription tag="ul" theme="invert">
+				<ul>
+					{#each included?.map((i) => i.name) || [] as item}
 						<li>{item}</li>
 					{/each}
-				</Description>
-			</Box>
-		</InformativeBoxContainer>
+				</ul>
+			</InformativeBoxDescription>
+		</InformativeBox>
+		<InformativeBox alignment="center" class="max-h-full bg-grey-700">
+			<InformativeBoxIcon>
+				<AnunciosImportantes style="monochrome" />
+			</InformativeBoxIcon>
+			<InformativeBoxTitle theme="invert">{labels?.get('not-included')}</InformativeBoxTitle>
+			<InformativeBoxDescription tag="ul" theme="invert">
+				{#each not_included?.map((i) => i.name) || [] as item}
+					<li>{item}</li>
+				{/each}
+			</InformativeBoxDescription>
+		</InformativeBox>
+	</InformativeBoxContainer>
 	</div>
 	{#if contact}
 		<ContactCard let:Name class="bg-background-lightblue">

--- a/src/lib/components/directus/stopover/package-page.svelte
+++ b/src/lib/components/directus/stopover/package-page.svelte
@@ -17,8 +17,7 @@
 	import { buttonVariants } from '$ui/components/button';
 	import { NoIcon, Phone, Social } from '$ui/components/icon';
 	import { SpokenLanguages } from '$lib/components/site/items/languages';
-	import { Pill } from '$ui/components/pill';
-	import Icon from '$ui/components/pill/icon.svelte';
+	import { Pill, Text as PillText, Icon as PillIcon } from '$ui/components/pill';
 
 	export let stopover_package: PackageSchema;
 
@@ -89,21 +88,21 @@
 		<Breadcrum item={stopover_package} />
 		<ul class="mb-gutter flex flex-wrap gap-2 md:gap-4">
 			<li>
-				<Pill class="bg-primary-ultralight" let:Icon let:Text>
-					<Icon class="text-d3">☀️</Icon>
-					<Text class="text-primary">{nights + 1} {labels?.get('label.day_plural')}</Text>
-				</Pill>
-			</li>
-			<li>
-				<Pill class="bg-primary-ultradark" let:Text let:Icon>
-					<Icon class="text-d3">🌑</Icon>
-					<Text>{nights} {labels?.get('label.night_plural')}</Text>
-				</Pill>
-			</li>
-			<li>
-				<Pill class="border-grey-600 bg-common-white " let:Text>
-					<Text class="text-grey-600">{labels?.get('option.stay_region.' + stay_region)}</Text>
-				</Pill>
+			<Pill class="bg-primary-ultralight">
+				<PillIcon class="text-d3">☀️</PillIcon>
+				<PillText class="text-primary">{nights + 1} {labels?.get('label.day_plural')}</PillText>
+			</Pill>
+		</li>
+		<li>
+			<Pill class="bg-primary-ultradark">
+				<PillIcon class="text-d3">🌑</PillIcon>
+				<PillText>{nights} {labels?.get('label.night_plural')}</PillText>
+			</Pill>
+		</li>
+		<li>
+			<Pill class="border-grey-600 bg-common-white ">
+				<PillText class="text-grey-600">{labels?.get('option.stay_region.' + stay_region)}</PillText>
+			</Pill>
 			</li>
 		</ul>
 		<Body size="body-large" class="mb-petit">

--- a/src/lib/components/directus/stopover/tours-page.svelte
+++ b/src/lib/components/directus/stopover/tours-page.svelte
@@ -17,7 +17,7 @@
 	import { Alert } from '$lib/components/ui/alerts/alert';
 	import { buttonVariants } from '$ui/components/button';
 	import { Globe, NoIcon, Phone, Filled, Regular, Social } from '$ui/components/icon';
-	import { Pill } from '$ui/components/pill';
+	import { Pill, Text as PillText, Icon as PillIcon } from '$ui/components/pill';
 	import { MapContainer } from '$lib/components/site/items/maps';
 
 	export let stopover_tour: TourSchema;
@@ -172,9 +172,9 @@
 		<ul class="flex flex-wrap gap-2 lg:[grid-area:categories]">
 			{#each category || [] as cat}
 				<li>
-					<Pill thickness="slim" class="bg-grey-100" let:Text>
-						<Text class="text-grey-600">{labels?.get(`tour-category-${cat}`)}</Text>
-					</Pill>
+				<Pill thickness="slim" class="bg-grey-100">
+					<PillText class="text-grey-600">{labels?.get(`tour-category-${cat}`)}</PillText>
+				</Pill>
 				</li>
 			{:else}
 				<li>
@@ -247,56 +247,54 @@
 					<Body class="mb-4">{description}</Body>
 					<ul class="flex flex-wrap gap-2 md:gap-4">
 						<li>
-							<Pill
-								let:Text
-								let:Icon
-								class={includes_admission ? 'bg-system-success-faded' : 'bg-grey-700'}
-							>
-								{#if includes_admission}
-									<Icon>
-										<Regular.Check
-											class={includes_admission ? 'fill-system-success' : 'fill-common-white'}
-										/>
-									</Icon>
-								{:else}
-									<Icon>
-										<Regular.Close
-											class={includes_admission ? 'fill-system-success' : 'fill-common-white'}
-										/>
-									</Icon>
-								{/if}
-								<Text class={includes_admission ? 'text-system-success' : 'text-common-white'}>
-									{includes_admission
-										? labels?.get('admision-included')
-										: labels?.get('admision-not-included')}
-								</Text>
-								<Icon>
-									<Filled.Ticket
+						<Pill
+							class={includes_admission ? 'bg-system-success-faded' : 'bg-grey-700'}
+						>
+							{#if includes_admission}
+								<PillIcon>
+									<Regular.Check
 										class={includes_admission ? 'fill-system-success' : 'fill-common-white'}
 									/>
-								</Icon>
-							</Pill>
+								</PillIcon>
+							{:else}
+								<PillIcon>
+									<Regular.Close
+										class={includes_admission ? 'fill-system-success' : 'fill-common-white'}
+									/>
+								</PillIcon>
+							{/if}
+							<PillText class={includes_admission ? 'text-system-success' : 'text-common-white'}>
+								{includes_admission
+									? labels?.get('admision-included')
+									: labels?.get('admision-not-included')}
+							</PillText>
+							<PillIcon>
+								<Filled.Ticket
+									class={includes_admission ? 'fill-system-success' : 'fill-common-white'}
+								/>
+							</PillIcon>
+						</Pill>
 						</li>
 						<li>
-							<Pill let:Text let:Icon class="bg-background-lightblue" theme="transparent">
-								<Icon>
-									<svelte:component this={getTourTypeIcon(type)} class="fill-primary" />
-								</Icon>
-								<Text class="text-primary">
-									{getTourTypeLabel(type)}
-								</Text>
-							</Pill>
+						<Pill class="bg-background-lightblue" theme="transparent">
+							<PillIcon>
+								<svelte:component this={getTourTypeIcon(type)} class="fill-primary" />
+							</PillIcon>
+							<PillText class="text-primary">
+								{getTourTypeLabel(type)}
+							</PillText>
+						</Pill>
 						</li>
 						<li>
-							<Pill let:Text let:Icon class="bg-background-lightblue" theme="transparent">
-								<Icon>
-									<Filled.Time class="fill-primary" title={labels?.get('duration')} />
-								</Icon>
-								<Text class="text-primary">
-									{duration}
-									{labels?.get('minutes')}
-								</Text>
-							</Pill>
+						<Pill class="bg-background-lightblue" theme="transparent">
+							<PillIcon>
+								<Filled.Time class="fill-primary" title={labels?.get('duration')} />
+							</PillIcon>
+							<PillText class="text-primary">
+								{duration}
+								{labels?.get('minutes')}
+							</PillText>
+						</Pill>
 						</li>
 					</ul>
 				</li>

--- a/src/lib/components/directus/stopover/tours-page.svelte
+++ b/src/lib/components/directus/stopover/tours-page.svelte
@@ -31,7 +31,6 @@
 	const {
 		main_image,
 		duration,
-		experience_category,
 		start_time,
 		meeting_point,
 		end_point,
@@ -175,15 +174,6 @@
 		<Heading tag="h2" class="text-primary lg:my-0 lg:[grid-area:title]" {customcn}>
 			{labels?.get('tour-experience')}
 		</Heading>
-		<ul class="flex flex-wrap gap-2 lg:[grid-area:categories]">
-			{#if experience_category?.translations?.[0]?.label}
-				<li>
-					<Pill thickness="slim" class="bg-grey-100">
-						<PillText class="text-grey-600">{experience_category.translations[0].label}</PillText>
-					</Pill>
-				</li>
-			{/if}
-		</ul>
 		<div class="my-6 space-y-4 lg:my-0 lg:[grid-area:details]">
 			<div class="flex items-center-safe gap-2 md:gap-4">
 				<Globe class="size-6 fill-secondary" title={labels?.get('languages')} />

--- a/src/lib/components/directus/stopover/tours-page.svelte
+++ b/src/lib/components/directus/stopover/tours-page.svelte
@@ -9,7 +9,13 @@
 	import { BaseTextContent } from '$lib/components/site/text-content/base';
 	import { BannerAlert } from '$lib/components/site/text-content/banner-alert';
 	import { isStopoverTourTranslations } from '$lib/directus/tours/utlis';
-	import { InformativeBoxContainer } from '$ui/components/boxes/informative';
+	import {
+		InformativeBoxContainer,
+		InformativeBox,
+		InformativeBoxIcon,
+		InformativeBoxTitle,
+		InformativeBoxDescription
+	} from '$ui/components/boxes/informative';
 	import { AnunciosImportantes, CheckIn, Tiquetes } from '$ui/components/pictograms';
 	import { Body, Heading } from '$ui/components/typography';
 	import { ContactCard } from '$lib/components/site/items/cards/contact';
@@ -333,34 +339,34 @@
 		{/if}
 	</div>
 	<div>
-		<InformativeBoxContainer let:Box>
-			<Box alignment="center" class="border-primary bg-primary" let:Icon let:Title let:Description>
-				<Icon>
-					<CheckIn style="transparent" />
-				</Icon>
-				<Title theme="invert">
-					{labels?.get('included')}
-				</Title>
-				<Description tag="ul" theme="invert">
-					<ul>
-						{#each included?.map((i) => i.name) || [] as item}
-							<li>{item}</li>
-						{/each}
-					</ul>
-				</Description>
-			</Box>
-			<Box alignment="center" class="bg-grey-700" let:Icon let:Title let:Description>
-				<Icon>
-					<AnunciosImportantes style="monochrome" />
-				</Icon>
-				<Title theme="invert">{labels?.get('not-included')}</Title>
-				<Description tag="ul" theme="invert">
-					{#each not_included?.map((i) => i.name) || [] as item}
+	<InformativeBoxContainer>
+		<InformativeBox alignment="center" class="border-primary bg-primary">
+			<InformativeBoxIcon>
+				<CheckIn style="transparent" />
+			</InformativeBoxIcon>
+			<InformativeBoxTitle theme="invert">
+				{labels?.get('included')}
+			</InformativeBoxTitle>
+			<InformativeBoxDescription tag="ul" theme="invert">
+				<ul>
+					{#each included?.map((i) => i.name) || [] as item}
 						<li>{item}</li>
 					{/each}
-				</Description>
-			</Box>
-		</InformativeBoxContainer>
+				</ul>
+			</InformativeBoxDescription>
+		</InformativeBox>
+		<InformativeBox alignment="center" class="bg-grey-700">
+			<InformativeBoxIcon>
+				<AnunciosImportantes style="monochrome" />
+			</InformativeBoxIcon>
+			<InformativeBoxTitle theme="invert">{labels?.get('not-included')}</InformativeBoxTitle>
+			<InformativeBoxDescription tag="ul" theme="invert">
+				{#each not_included?.map((i) => i.name) || [] as item}
+					<li>{item}</li>
+				{/each}
+			</InformativeBoxDescription>
+		</InformativeBox>
+	</InformativeBoxContainer>
 	</div>
 	{#if operator}
 		{@const { name, main_image, contact, network } = operator}

--- a/src/lib/components/directus/stopover/tours-page.svelte
+++ b/src/lib/components/directus/stopover/tours-page.svelte
@@ -31,7 +31,7 @@
 	const {
 		main_image,
 		duration,
-		category,
+		experience_category,
 		start_time,
 		meeting_point,
 		end_point,
@@ -176,17 +176,13 @@
 			{labels?.get('tour-experience')}
 		</Heading>
 		<ul class="flex flex-wrap gap-2 lg:[grid-area:categories]">
-			{#each category || [] as cat}
+			{#if experience_category?.translations?.[0]?.label}
 				<li>
-				<Pill thickness="slim" class="bg-grey-100">
-					<PillText class="text-grey-600">{labels?.get(`tour-category-${cat}`)}</PillText>
-				</Pill>
+					<Pill thickness="slim" class="bg-grey-100">
+						<PillText class="text-grey-600">{experience_category.translations[0].label}</PillText>
+					</Pill>
 				</li>
-			{:else}
-				<li>
-					<Alert>Es necesario asociar el tour operador al tour</Alert>
-				</li>
-			{/each}
+			{/if}
 		</ul>
 		<div class="my-6 space-y-4 lg:my-0 lg:[grid-area:details]">
 			<div class="flex items-center-safe gap-2 md:gap-4">

--- a/src/lib/components/site/items/cards/contact/avatar.svelte
+++ b/src/lib/components/site/items/cards/contact/avatar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	import { Avatar, type Props as CMAvatarProps } from '$ui/components/avatar';
+	import { Avatar, Image, Fallback, type Props as CMAvatarProps } from '$ui/components/avatar';
 
 	type $$Props = CMAvatarProps;
 
@@ -8,6 +8,6 @@
 	export { className as class };
 </script>
 
-<Avatar let:Image let:Fallback class={cn('[grid-area:avatar]', className)}>
+<Avatar class={cn('[grid-area:avatar]', className)}>
 	<slot {Image} {Fallback} />
 </Avatar>

--- a/src/lib/directus/stopover_mixed_experience_module.ts
+++ b/src/lib/directus/stopover_mixed_experience_module.ts
@@ -8,11 +8,27 @@ const stopoverMixedExperienceTranslationSchema = z.object({
 	primary_cta_label: z.string().nullable().optional(),
 	primary_cta_url: z.string().nullable().optional(),
 	secondary_cta_label: z.string().nullable().optional(),
-	secondary_cta_url: z.string().nullable().optional()
+	secondary_cta_url: z.string().nullable().optional(),
+	reference_point_label: z.string().nullable().optional(),
+	filter_language_label: z.string().nullable().optional(),
+	filter_category_label: z.string().nullable().optional(),
+	filter_discount_label: z.string().nullable().optional(),
+	filter_duration_label: z.string().nullable().optional(),
+	filter_distance_label: z.string().nullable().optional(),
+	filter_apply_label: z.string().nullable().optional()
+});
+
+const stopoverMixedExperienceSourceTranslationSchema = z.object({
+	languages_code: z.string().nullable().optional(),
+	label: z.string().nullable().optional()
 });
 
 const stopoverMixedExperienceSourceSchema = z.object({
+	id: z.number().optional(),
 	entity_type: z.string().nullable().optional(),
+	max_items: z.number().nullable().optional(),
+	status: z.string().nullable().optional(),
+	translations: stopoverMixedExperienceSourceTranslationSchema.array().nullable().optional(),
 	item: z.union([z.number(), z.string(), z.record(z.string(), any())]).nullable().optional()
 });
 
@@ -20,6 +36,11 @@ const stopoverMixedExperienceModuleSchema = z.object({
 	key: z.string(),
 	max_items: z.number().optional(),
 	prefilter: z.string().nullable().optional(),
+	filter_language_enabled: z.boolean().nullable().optional(),
+	filter_category_enabled: z.boolean().nullable().optional(),
+	filter_discount_enabled: z.boolean().nullable().optional(),
+	filter_duration_enabled: z.boolean().nullable().optional(),
+	filter_distance_enabled: z.boolean().nullable().optional(),
 	translations: stopoverMixedExperienceTranslationSchema.array().nullable().optional(),
 	sources: stopoverMixedExperienceSourceSchema.array().nullable().optional(),
 	items: any().array().optional()
@@ -28,10 +49,43 @@ const stopoverMixedExperienceModuleSchema = z.object({
 const stopoverMixedExperienceModuleQueryFields = [
 	'key',
 	'max_items',
-	'prefilter'
+	'prefilter',
+	'filter_language_enabled',
+	'filter_category_enabled',
+	'filter_discount_enabled',
+	'filter_duration_enabled',
+	'filter_distance_enabled',
+	'translations.languages_code',
+	'translations.title',
+	'translations.description',
+	'translations.disclaimer_text',
+	'translations.primary_cta_label',
+	'translations.primary_cta_url',
+	'translations.secondary_cta_label',
+	'translations.secondary_cta_url',
+	'translations.reference_point_label',
+	'translations.filter_language_label',
+	'translations.filter_category_label',
+	'translations.filter_discount_label',
+	'translations.filter_duration_label',
+	'translations.filter_distance_label',
+	'translations.filter_apply_label',
+	'sources.id',
+	'sources.entity_type',
+	'sources.max_items',
+	'sources.status',
+	'sources.translations.languages_code',
+	'sources.translations.label'
 ];
 
 type StopoverMixedExperienceModuleSchema = z.infer<typeof stopoverMixedExperienceModuleSchema>;
+type StopoverMixedExperienceTranslationSchema = z.infer<
+	typeof stopoverMixedExperienceTranslationSchema
+>;
+type StopoverMixedExperienceSourceSchema = z.infer<typeof stopoverMixedExperienceSourceSchema>;
+type StopoverMixedExperienceSourceTranslationSchema = z.infer<
+	typeof stopoverMixedExperienceSourceTranslationSchema
+>;
 
 const isStopoverMixedExperienceModuleSchema = (
 	value: unknown
@@ -40,8 +94,16 @@ const isStopoverMixedExperienceModuleSchema = (
 
 export {
 	stopoverMixedExperienceModuleSchema,
+	stopoverMixedExperienceTranslationSchema,
+	stopoverMixedExperienceSourceSchema,
+	stopoverMixedExperienceSourceTranslationSchema,
 	isStopoverMixedExperienceModuleSchema,
 	stopoverMixedExperienceModuleQueryFields
 };
 
-export type { StopoverMixedExperienceModuleSchema };
+export type {
+	StopoverMixedExperienceModuleSchema,
+	StopoverMixedExperienceTranslationSchema,
+	StopoverMixedExperienceSourceSchema,
+	StopoverMixedExperienceSourceTranslationSchema
+};

--- a/src/lib/directus/tours/index.ts
+++ b/src/lib/directus/tours/index.ts
@@ -21,12 +21,12 @@ const getTourQuery = ({ locale, category, subCategory, article }: DirectusReques
 		'start_time',
 		'meeting_point',
 		'end_point',
-		'category',
 		'supported_languages',
 		'pilar',
 		'promo_code',
 		'promo_discount_amount',
 		'promo_discount_percent',
+		{ experience_category: ['id', { translations: ['languages_code', 'label'] }] } as any,
 		{ gallery: ['directus_files_id'] },
 		{ operator: ['name', 'main_image', 'contact', 'network'] },
 		{
@@ -44,7 +44,7 @@ const getTourQuery = ({ locale, category, subCategory, article }: DirectusReques
 			]
 		},
 		{ parent_page: pagePathFields }
-	],
+	] as any,
 	filter: {
 		_and: [
 			{ translations: { languages_code: { _eq: locale } } },
@@ -58,7 +58,12 @@ const getTourQuery = ({ locale, category, subCategory, article }: DirectusReques
 			},
 			{ parent_page: { parent: { parent: { translations: { path: { _eq: locale } } } } } }
 		]
-	}
+	} as any,
+	deep: {
+		experience_category: {
+			translations: { _filter: { languages_code: { _eq: locale } } }
+		}
+	} as any
 });
 
 const getPublishedTours = async (filters: DirectusRequestBody) => {

--- a/src/lib/domain/tours/mappers.ts
+++ b/src/lib/domain/tours/mappers.ts
@@ -55,7 +55,7 @@ export interface TourCardViewModel {
 	mainImage: string;
 	name: string;
 	duration?: string;
-	category?: string;
+	categoryLabel?: string;
 	operator?: {
 		name: string;
 		image?: string;
@@ -69,12 +69,15 @@ export function mapTourToCardViewModel(
 	locale: string
 ): TourCardViewModel {
 	const translation = getTourTranslation(tour, locale);
+	const categoryTranslation = tour.experience_category?.translations?.find(
+		(t) => t.languages_code === locale
+	) ?? tour.experience_category?.translations?.[0];
 
 	return {
 		mainImage: tour.main_image,
 		name: translation?.name || 'Tour',
 		duration: tour.duration ?? undefined,
-		category: tour.category ?? undefined,
+		categoryLabel: categoryTranslation?.label ?? undefined,
 		operator: tour.operator ? {
 			name: tour.operator.name,
 			image: tour.operator.main_image ?? undefined

--- a/src/lib/domain/tours/types.ts
+++ b/src/lib/domain/tours/types.ts
@@ -49,6 +49,17 @@ const parentPageSchema = z.object({
 
 type ParentPage = z.infer<typeof parentPageSchema>;
 
+// Experience category (M2O relation to a shared categories table)
+const experienceCategoryTranslationSchema = z.object({
+	languages_code: z.string().nullable().optional(),
+	label: z.string().nullable().optional()
+});
+
+const experienceCategorySchema = z.object({
+	id: z.number().nullable().optional(),
+	translations: experienceCategoryTranslationSchema.array().nullable().optional()
+});
+
 // Complete Tour Domain Model
 const tourSchema = z.object({
 	main_image: z.string(),
@@ -56,7 +67,7 @@ const tourSchema = z.object({
 	start_time: z.string().nullish(),
 	meeting_point: z.string().nullish(),
 	end_point: z.string().nullish(),
-	category: z.string().nullish(),
+	experience_category: experienceCategorySchema.nullable().optional(),
 	supported_languages: z.string().array().nullish(),
 	pilar: z.string().array().nullish(),
 	promo_code: z.string().nullish(),
@@ -80,7 +91,9 @@ export {
 	tourTranslationSchema,
 	tourOperatorSchema,
 	fileSchema,
-	parentPageSchema
+	parentPageSchema,
+	experienceCategorySchema,
+	experienceCategoryTranslationSchema
 };
 
 export type {

--- a/src/routes/[...path]/+page.server.ts
+++ b/src/routes/[...path]/+page.server.ts
@@ -138,6 +138,38 @@ const sortAndTrimPromoItems = <T extends SortablePromoItem>(items: T[], maxItems
 const isPromotionPrefilter = (prefilter: string | null | undefined) =>
 	(prefilter ?? '').toLocaleLowerCase() === 'promotions';
 
+// Per-collection extra fields needed for client-side filters and sorting.
+// Tours expose `meeting_point` (GeoJSON); places expose `location` (GeoJSON).
+// Keeping them per-collection avoids asking Directus for fields that don't exist.
+const getCollectionSpecificFields = (collection: string): string[] => {
+	const categoryFields = [
+		'experience_category.id',
+		'experience_category.translations.languages_code',
+		'experience_category.translations.label'
+	];
+	if (collection === 'stopover_tour') {
+		return [
+			'id',
+			'duration',
+			'meeting_point',
+			'supported_languages',
+			'date_created',
+			...categoryFields
+		];
+	}
+	if (collection === 'stopover_place_to_visit') {
+		return [
+			'id',
+			'duration',
+			'location',
+			'supported_languages',
+			'date_created',
+			...categoryFields
+		];
+	}
+	return ['id', 'date_created'];
+};
+
 const buildMixedPromoItemsQuery = (
 	locale: string,
 	collection: string,
@@ -148,6 +180,7 @@ const buildMixedPromoItemsQuery = (
 		'main_image',
 		'promo_discount_percent',
 		'promo_discount_amount',
+		...getCollectionSpecificFields(collection),
 		{ translations: ['name', 'path', 'promo_name'] },
 		{ parent_page: pagePathFields }
 	] as any,
@@ -157,6 +190,9 @@ const buildMixedPromoItemsQuery = (
 	deep: {
 		translations: {
 			_filter: getItemTranslationsFilter(collection, locale)
+		},
+		experience_category: {
+			translations: { _filter: { languages_code: { _eq: locale } } }
 		},
 		parent_page: {
 			translations: { _filter: { languages_code: { _eq: locale } } },
@@ -281,18 +317,38 @@ export async function load(event) {
 			'key',
 			'max_items',
 			'prefilter',
+			'filter_language_enabled',
+			'filter_category_enabled',
+			'filter_discount_enabled',
+			'filter_duration_enabled',
+			'filter_distance_enabled',
 			{
 				translations: [
 					'languages_code',
 					'title',
+					'description',
+					'disclaimer_text',
 					'primary_cta_label',
 					'primary_cta_url',
 					'secondary_cta_label',
-					'secondary_cta_url'
+					'secondary_cta_url',
+					'reference_point_label',
+					'filter_language_label',
+					'filter_category_label',
+					'filter_discount_label',
+					'filter_duration_label',
+					'filter_distance_label',
+					'filter_apply_label'
 				]
 			},
 			{
-				sources: ['entity_type']
+				sources: [
+					'id',
+					'entity_type',
+					'max_items',
+					'status',
+					{ translations: ['languages_code', 'label'] }
+				]
 			}
 		] as any,
 		deep: {
@@ -300,6 +356,15 @@ export async function load(event) {
 				_filter: {
 					languages_code: {
 						_eq: locale
+					}
+				}
+			},
+			sources: {
+				translations: {
+					_filter: {
+						languages_code: {
+							_eq: locale
+						}
 					}
 				}
 			}
@@ -366,13 +431,17 @@ export async function load(event) {
 				}))
 			);
 
+		// Mixed modules receive the full un-sorted, un-trimmed pool so the client
+		// component can apply filters, sorting and max_items caps on the client side
+		// without hitting the server again. `sorted_items` keeps its key for
+		// backwards compatibility but is no longer sorted nor capped here.
 		return {
 			module_key: (moduleConfig as Record<string, unknown>).key,
 			prefilter,
 			limit,
 			sources,
 			queries,
-			sorted_items: sortAndTrimPromoItems(mergedItems as SortablePromoItem[], limit)
+			sorted_items: mergedItems
 		};
 	})();
 

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -226,6 +226,78 @@ const mixedEntityTypeToCollectionMap: Record<string, keyof Schema> = {
 const getMixedSourceCollection = (entityType: string) =>
 	pathOr(null, [entityType], mixedEntityTypeToCollectionMap);
 
+// Shared field list for the mixed experience module detail queries.
+// Keep in sync with buildMixedConfigQuery in +page.server.ts.
+const mixedModuleDetailFields = [
+	'key',
+	'max_items',
+	'prefilter',
+	'filter_language_enabled',
+	'filter_category_enabled',
+	'filter_discount_enabled',
+	'filter_duration_enabled',
+	'filter_distance_enabled',
+	{
+		translations: [
+			'languages_code',
+			'title',
+			'description',
+			'disclaimer_text',
+			'primary_cta_label',
+			'primary_cta_url',
+			'secondary_cta_label',
+			'secondary_cta_url',
+			'reference_point_label',
+			'filter_language_label',
+			'filter_category_label',
+			'filter_discount_label',
+			'filter_duration_label',
+			'filter_distance_label',
+			'filter_apply_label'
+		]
+	},
+	{
+		sources: [
+			'id',
+			'entity_type',
+			'max_items',
+			'status',
+			{ translations: ['languages_code', 'label'] }
+		]
+	}
+];
+
+// Per-collection extra fields for source items, needed by client-side filters/sort.
+// Tours use `meeting_point`; places use `location`. Both are GeoJSON points.
+const getSourceItemExtraFields = (collectionName: string): string[] => {
+	const categoryFields = [
+		'experience_category.id',
+		'experience_category.translations.languages_code',
+		'experience_category.translations.label'
+	];
+	if (collectionName === 'stopover_tour') {
+		return [
+			'id',
+			'duration',
+			'meeting_point',
+			'supported_languages',
+			'date_created',
+			...categoryFields
+		];
+	}
+	if (collectionName === 'stopover_place_to_visit') {
+		return [
+			'id',
+			'duration',
+			'location',
+			'supported_languages',
+			'date_created',
+			...categoryFields
+		];
+	}
+	return ['id', 'date_created'];
+};
+
 const buildModuleQuery = (
 	{ max_items, highlight_only, sort, promo_only, pilar }: StopoverHotelModuleSchema,
 	collectionName: string,
@@ -269,9 +341,21 @@ const buildModuleQuery = (
 	limit: -1
 });
 
+const buildMixedModuleDeepFilter = (locale: string) => ({
+	translations: {
+		_filter: { languages_code: { _eq: locale } }
+	},
+	sources: {
+		translations: {
+			_filter: { languages_code: { _eq: locale } }
+		}
+	}
+});
+
 const getMixedModuleDetailsByKey = async (
 	moduleCollection: MixedModuleCollection,
-	moduleKey: string
+	moduleKey: string,
+	locale?: string
 ) => {
 	const collections = getMixedModuleCollections(moduleCollection);
 
@@ -279,31 +363,13 @@ const getMixedModuleDetailsByKey = async (
 		const response = await getItems(
 			collection,
 			{
-				fields: [
-					'key',
-					'max_items',
-					'prefilter',
-					{
-						translations: [
-							'languages_code',
-							'title',
-							'description',
-							'disclaimer_text',
-							'primary_cta_label',
-							'primary_cta_url',
-							'secondary_cta_label',
-							'secondary_cta_url'
-						]
-					},
-					{
-						sources: ['entity_type']
-					}
-				],
+				fields: mixedModuleDetailFields,
 				filter: {
 					key: {
 						_eq: moduleKey
 					}
 				},
+				deep: locale ? buildMixedModuleDeepFilter(locale) : undefined,
 				limit: 1
 			} as any,
 			null
@@ -319,7 +385,8 @@ const getMixedModuleDetailsByKey = async (
 };
 
 const getFirstMixedModule = async (
-	moduleCollection: MixedModuleCollection
+	moduleCollection: MixedModuleCollection,
+	locale?: string
 ) => {
 	const collections = getMixedModuleCollections(moduleCollection);
 
@@ -327,26 +394,8 @@ const getFirstMixedModule = async (
 		const response = await getItems(
 			collection,
 			{
-				fields: [
-					'key',
-					'max_items',
-					'prefilter',
-					{
-						translations: [
-							'languages_code',
-							'title',
-							'description',
-							'disclaimer_text',
-							'primary_cta_label',
-							'primary_cta_url',
-							'secondary_cta_label',
-							'secondary_cta_url'
-						]
-					},
-					{
-						sources: ['entity_type']
-					}
-				],
+				fields: mixedModuleDetailFields,
+				deep: locale ? buildMixedModuleDeepFilter(locale) : undefined,
 				limit: 1
 			} as any,
 			null
@@ -372,6 +421,7 @@ const buildMixedSourceItemsQuery = (
 		'main_image',
 		'promo_discount_percent',
 		'promo_discount_amount',
+		...getSourceItemExtraFields(collectionName),
 		{ translations: ['name', 'path', 'promo_name'] },
 		{ parent_page: pagePathFields }
 	] as any,
@@ -381,6 +431,9 @@ const buildMixedSourceItemsQuery = (
 	deep: {
 		translations: {
 			_filter: getTranslationsFilter(collectionName, locale)
+		},
+		experience_category: {
+			translations: { _filter: { languages_code: { _eq: locale } } }
 		},
 		parent_page: {
 			translations: { _filter: { languages_code: { _eq: locale } } },
@@ -403,7 +456,7 @@ const getMixedExperienceEntities = async (
 	let workingModule: StopoverMixedExperienceModuleSchema | null = module;
 
 	if ((isNil(workingModule.sources) || isEmpty(workingModule.sources)) && workingModule.key) {
-		workingModule = await getMixedModuleDetailsByKey(moduleCollection, workingModule.key);
+		workingModule = await getMixedModuleDetailsByKey(moduleCollection, workingModule.key, locale);
 	}
 
 	if (!workingModule || isNil(workingModule.sources) || isEmpty(workingModule.sources)) return [];
@@ -437,7 +490,9 @@ const getMixedExperienceEntities = async (
 			(entry.items as Array<Record<string, unknown>>).map((item) => ({ ...item, _collection: entry.collection }))
 		);
 
-	return sortAndTrimPromoItems(flattenedItems, maxItems);
+	// Mixed modules return the full pool; filtering, sorting and the max_items cap
+	// are applied client-side inside the mixed-experience-module component.
+	return flattenedItems;
 };
 
 const getStopoverHotelModuleById = async (moduleId: string | number) => {
@@ -474,7 +529,7 @@ const getModuleRequest = (sections: SectionContentSchema, locale: string) => (pa
 		moduleCollection === 'stopover_mixed_experiece_module'
 	) {
 		if (!isStopoverMixedExperienceModuleSchema(module)) {
-			return getFirstMixedModule(moduleCollection).then((mixedModule) => {
+			return getFirstMixedModule(moduleCollection, locale).then((mixedModule) => {
 				if (!mixedModule) return [];
 				return getMixedExperienceEntities(mixedModule, moduleCollection, locale);
 			});


### PR DESCRIPTION
# Mixed Experience Module — Activities & Tours Merge

> Commit: `03885f5` — `feat: merge tour and activities part 1 ready to review`

## Overview

The **Mixed Experience Module** (`stopover_mixed_experience_module`) is a new Directus-backed content block that replaces the need for separate activity and tour modules. It allows CMS editors to curate a single card grid sourced from **any combination** of entity types: activities, tours, hotels, restaurants, packages, and transportation.

The module renders using the `PromoShow` card component, with an optional entity-type badge ("Tour" / "Activity" / "Actividad" / etc.) that is inferred automatically from the source collection.

---

## What Changed

### New files

| File | Purpose |
|------|---------|
| `src/lib/directus/stopover_mixed_experience_module.ts` | Zod schema + type exports for the new module |
| `src/lib/components/directus/general-components/mixed-experience-module/mixed-experience-module.svelte` | Svelte component that renders the card grid |
| `src/lib/components/directus/general-components/mixed-experience-module/index.ts` | Barrel export |

### Modified files

| File | What changed |
|------|-------------|
| `src/routes/[...path]/+page.server.ts` | Added mixed-module detection + multi-collection item fetching |
| `src/routes/utils.ts` | Extended collection aliases, added shared sort logic, added mixed module support |
| `src/lib/directus/section.ts` | Added mixed module to section content schema |
| `src/lib/directus/content-group.ts` | Added mixed module to content group schema |
| `src/lib/directus/stopover_hotel_module.ts` | Minor cleanup |
| `src/lib/components/directus/utils.ts` | Shared utility additions |
| `src/lib/components/site/navigation/home/navigation-home.svelte` | UI fix for home navigation |

---

## Directus Schema

The CMS collection is `stopover_mixed_experience_module` (also tolerates the legacy typo variant `stopover_mixed_experiece_module`).

```
stopover_mixed_experience_module
├── key                   string (required)
├── max_items             number
├── prefilter             string | null  →  "promotions" to show only discounted items
├── sources[]
│   ├── entity_type       string  →  e.g. "activities", "tours", "hotels"
│   └── item              number | string | object | null
└── translations[]
    ├── languages_code
    ├── title
    ├── description
    ├── disclaimer_text
    ├── primary_cta_label
    ├── primary_cta_url
    ├── secondary_cta_label
    └── secondary_cta_url
```

### `entity_type` accepted values

The following values (and their aliases) are all resolved to the correct Directus collection:

| `entity_type` value | Resolves to |
|---------------------|-------------|
| `activities`, `activity`, `stopover_place_to_visit`, `stopover_activity` | `stopover_place_to_visit` |
| `tours`, `tour`, `stopover_tour`, `stopover_tours` | `stopover_tour` |
| `hotels`, `hotel`, `stopover_hotel`, `stopover_hotels` | `stopover_hotels` |
| `restaurants`, `restaurant`, `stopover_restaurant`, `stopover_restaurants` | `stopover_restaurants` |
| `packages`, `package`, `stopover_package`, `stopover_packages` | `stopover_package` |
| `transportation`, `transport`, `stopover_transportation`, `stopover_transport` | `stopover_transportation` |

---

## Data Flow

```
+page.server.ts
  └── getModulesConfigList(sections)
        ↓ Finds all stopover_mixed_experience_module entries in sections/content-groups
  └── For each mixed module:
        └── Reads sources[].entity_type
        └── Queries each collection via buildMixedPromoItemsQuery()
              ↓ Fields: priority, main_image, promo_discount_*, translations, parent_page
        └── Merges items from all sources
        └── Sorts merged list via comparePromoItems()
        └── Trims to max_items
  └── Passes result to $page.data.mixed_items_query_output

mixed-experience-module.svelte
  └── Reads $page.data.mixed_items_query_output.sorted_items
  └── Renders PromoShow card per item
  └── Infers entity-type badge from promo._collection
  └── Renders primary / secondary CTAs from module translations
```

---

## Sorting Logic

Items from all sources are merged and sorted by the following criteria (in order):

1. **Priority** — higher number wins (`priority DESC`)
2. **Promo discount percent** — higher discount wins (`promo_discount_percent DESC`)
3. **Date created** — older items ranked first (`date_created ASC`) — "antiguedad"
4. **Name** — alphabetical fallback (`name ASC`, locale-aware)

```ts
// src/routes/utils.ts
const comparePromoItems = (a, b) => {
  byPriority → byDiscountPercent → byDate → byName
};
```

---

## Prefilter: Promotions Mode

When `prefilter` is set to `"promotions"` (case-insensitive), the module only fetches items that have at least one of:

- `promo_discount_amount` set
- `promo_discount_percent` set
- `promo_code` set

---

## Entity Type Badge

The `getEntityTypeLabel()` function in the Svelte component maps a collection name to a localised label shown on the card:

| Locale | Tour label | Activity label |
|--------|-----------|----------------|
| `en` | Tour | Activity |
| `es` | Tour | Actividad |
| `pt` | Tour | Atividade |

The badge only appears when the item also has a promo discount displayed.

---

## CMS Setup Checklist

When creating a new `stopover_mixed_experience_module` in Directus:

- [ ] Add the module to a **section** (`section_content`) or to a **content group** (`content_group.content`)
- [ ] Configure at least one entry in `sources[]` with the correct `entity_type`
- [ ] Set `max_items` (recommended: 4–8)
- [ ] Set `prefilter` to `"promotions"` if the block should only show discounted items
- [ ] Add translations for each language (at minimum title + one CTA pair)
- [ ] Verify that the referenced entities have `parent_page` set (required for card links to work)

---

## Known Limitations / Next Steps

- **Part 1 only**: The current implementation fetches items but does not yet support inline item pinning from the CMS (`sources[].item` is typed but not consumed).
- The legacy typo variant `stopover_mixed_experiece_module` is supported as a fallback — this alias should be removed once the CMS collection is fully migrated.
- Sort by discount amount (`promo_discount_amount`) is not yet part of the primary sort key; only `promo_discount_percent` is considered.
